### PR TITLE
update against STRICT STANDARDS

### DIFF
--- a/vtlib/Vtiger/FieldBasic.php
+++ b/vtlib/Vtiger/FieldBasic.php
@@ -141,13 +141,11 @@ class Vtiger_FieldBasic {
 			$this->sequence = $this->__getNextSequence();
 		}
 
-		if($this->quickcreate != 1) { // If enabled for display
-			if(!$this->quicksequence) {
-				$this->quicksequence = $this->__getNextQuickCreateSequence();
-			}
-		} else {
-			$this->quicksequence = null;
-		}
+		// If enabled for display
+		if($this->quickcreate != 1 && !$this->quicksequence)
+                    $this->quicksequence = $this->__getNextQuickCreateSequence();
+                else
+                    $this->quicksequence = null;
 
 		// Initialize other variables which are not done
 		if(!$this->table) $this->table = $moduleInstance->basetable;


### PR DESCRIPTION
$this->quicksequence needs to value something or NULL, not empty ('') because field is INT.

When a field with quickckreate = 3 and quicksequence empty for example, $this->quicksequence will value empty string after loop.
