### PR TITLE
Search for config-dev.inc.php without silencing errors. 

### DIFF
--- a/config.template.php
+++ b/config.template.php
@@ -205,7 +205,7 @@ $MINIMUM_CRON_FREQUENCY = 15;
 $cors_enabled_domains = '';
 
 // Override with developer settings
-if(file_exists('config-dev.inc.php)){
+if(file_exists('config-dev.inc.php')){
 	include('config-dev.inc.php');
 }
 

--- a/config.template.php
+++ b/config.template.php
@@ -205,6 +205,8 @@ $MINIMUM_CRON_FREQUENCY = 15;
 $cors_enabled_domains = '';
 
 // Override with developer settings
-@include('config-dev.inc.php');
+if(file_exists('config-dev.inc.php)){
+	include('config-dev.inc.php');
+}
 
 ?>


### PR DESCRIPTION
In some php installations when using @include_once, application fails with an apache segmentation fault.

Change searching config-dev.inc.php with file_exists