### PR TITLE
Customblocks

### DIFF
--- a/Smarty/templates/DetailView.tpl
+++ b/Smarty/templates/DetailView.tpl
@@ -329,6 +329,7 @@ function sendfile_email()
 																						</tr>
 																					{/if}
 																				</table>
+                                                                                                                                                                
 																				{if $header neq 'Comments'}
 																					{if $BLOCKINITIALSTATUS[$header] eq 1}
 																						<div style="width:auto;display:block;" id="tbl{$header|replace:' ':''}" >
@@ -336,6 +337,9 @@ function sendfile_email()
 																						<div style="width:auto;display:none;" id="tbl{$header|replace:' ':''}" >
 																						{/if}
 																							<table border=0 cellspacing=0 cellpadding=0 width="100%" class="small detailview_table">
+                                                                                                                                                                                            {if $CUSTOMBLOCKS.$header.custom}
+                                                                                                                                                                                                {include file=$CUSTOMBLOCKS.$header.tpl}
+                                                                                                                                                                                            {else}
 																								{foreach item=detail from=$detail}
 																									<tr style="height:25px" class="detailview_row">
 																										{foreach key=label item=data from=$detail}
@@ -382,6 +386,7 @@ function sendfile_email()
 																											{/foreach}
 																									</tr>
 																								{/foreach}
+                                                                                                                                                                                            {/if}
 																							</table>
 																						</div>
 																					{/if}

--- a/Smarty/templates/Inventory/InventoryDetailView.tpl
+++ b/Smarty/templates/Inventory/InventoryDetailView.tpl
@@ -244,51 +244,55 @@ function getListOfRecords(obj, sModule, iId,sParentTab)
 							{/if}
 							<table border=0 cellspacing=0 cellpadding=0 width="100%" class="small">
 
-	   {foreach item=detail from=$detail}
-	   <tr style="height:25px">
-		{foreach key=label item=data from=$detail}
-			{assign var=keyid value=$data.ui}
-			{assign var=keyval value=$data.value}
-			{assign var=keytblname value=$data.tablename}
-			{assign var=keyfldname value=$data.fldname}
-			{assign var=keyfldid value=$data.fldid}
-			{assign var=keyoptions value=$data.options}
-			{assign var=keysecid value=$data.secid}
-			{assign var=keyseclink value=$data.link}
-			{assign var=keycursymb value=$data.cursymb}
-			{assign var=keysalut value=$data.salut}
-			{assign var=keycntimage value=$data.cntimage}
-			{assign var=keyadmin value=$data.isadmin}
-			{assign var=display_type value=$data.displaytype}
-			{assign var=_readonly value=$data.readonly}
+            {if $CUSTOMBLOCKS.$header.custom}
+                {include file=$CUSTOMBLOCKS.$header.tpl}
+            {else}
+               {foreach item=detail from=$detail}
+               <tr style="height:25px">
+                    {foreach key=label item=data from=$detail}
+                            {assign var=keyid value=$data.ui}
+                            {assign var=keyval value=$data.value}
+                            {assign var=keytblname value=$data.tablename}
+                            {assign var=keyfldname value=$data.fldname}
+                            {assign var=keyfldid value=$data.fldid}
+                            {assign var=keyoptions value=$data.options}
+                            {assign var=keysecid value=$data.secid}
+                            {assign var=keyseclink value=$data.link}
+                            {assign var=keycursymb value=$data.cursymb}
+                            {assign var=keysalut value=$data.salut}
+                            {assign var=keycntimage value=$data.cntimage}
+                            {assign var=keyadmin value=$data.isadmin}
+                            {assign var=display_type value=$data.displaytype}
+                            {assign var=_readonly value=$data.readonly}
 
-				{if $label ne ''}
-					{if $keycntimage ne ''}
-						<td class="dvtCellLabel" align=right width=25%><input type="hidden" id="hdtxt_IsAdmin" value={$keyadmin}></input>{$keycntimage}</td>
-					{elseif $label neq 'Tax Class'}<!-- Avoid to display the label Tax Class -->
-						{if $keyid eq '71' || $keyid eq '72'}  <!--CurrencySymbol-->
-							<td class="dvtCellLabel" align=right width=25%><input type="hidden" id="hdtxt_IsAdmin" value={$keyadmin}></input>{$label} ({$keycursymb})</td>
-						{elseif $keyid eq '9'}
-							<td class="dvtCellLabel" align=right width=25%><input type="hidden" id="hdtxt_IsAdmin" value={$keyadmin}></input>{$label} {$APP.COVERED_PERCENTAGE}</td>
-						{else}
-							<td class="dvtCellLabel" align=right width=25%><input type="hidden" id="hdtxt_IsAdmin" value={$keyadmin}></input>{$label}</td>
-						{/if}
-					{/if}  
-					{if $EDIT_PERMISSION eq 'yes' && $display_type neq '2' && $_readonly eq '0'}
-						{* Performance Optimization Control *}
-						{if !empty($DETAILVIEW_AJAX_EDIT) }
-							{include file="DetailViewUI.tpl"}
-						{else}
-							{include file="DetailViewFields.tpl"}
-						{/if}
-						{* END *}
-					{else}
-						{include file="DetailViewFields.tpl"}
-					{/if}
-				{/if}
-		{/foreach}
-	   </tr>
-	   {/foreach}
+                                    {if $label ne ''}
+                                            {if $keycntimage ne ''}
+                                                    <td class="dvtCellLabel" align=right width=25%><input type="hidden" id="hdtxt_IsAdmin" value={$keyadmin}></input>{$keycntimage}</td>
+                                            {elseif $label neq 'Tax Class'}<!-- Avoid to display the label Tax Class -->
+                                                    {if $keyid eq '71' || $keyid eq '72'}  <!--CurrencySymbol-->
+                                                            <td class="dvtCellLabel" align=right width=25%><input type="hidden" id="hdtxt_IsAdmin" value={$keyadmin}></input>{$label} ({$keycursymb})</td>
+                                                    {elseif $keyid eq '9'}
+                                                            <td class="dvtCellLabel" align=right width=25%><input type="hidden" id="hdtxt_IsAdmin" value={$keyadmin}></input>{$label} {$APP.COVERED_PERCENTAGE}</td>
+                                                    {else}
+                                                            <td class="dvtCellLabel" align=right width=25%><input type="hidden" id="hdtxt_IsAdmin" value={$keyadmin}></input>{$label}</td>
+                                                    {/if}
+                                            {/if}  
+                                            {if $EDIT_PERMISSION eq 'yes' && $display_type neq '2' && $_readonly eq '0'}
+                                                    {* Performance Optimization Control *}
+                                                    {if !empty($DETAILVIEW_AJAX_EDIT) }
+                                                            {include file="DetailViewUI.tpl"}
+                                                    {else}
+                                                            {include file="DetailViewFields.tpl"}
+                                                    {/if}
+                                                    {* END *}
+                                            {else}
+                                                    {include file="DetailViewFields.tpl"}
+                                            {/if}
+                                    {/if}
+                    {/foreach}
+               </tr>
+               {/foreach}
+           {/if}
 	</table>
 	</div> <!-- Line added by SAKTI on 10th Apr, 2008 -->
 <!-- Entity information(blocks) display - ends -->

--- a/Smarty/templates/modules/Accounts/LBL_DESCRIPTION_INFORMATION_edit.tpl
+++ b/Smarty/templates/modules/Accounts/LBL_DESCRIPTION_INFORMATION_edit.tpl
@@ -1,0 +1,3 @@
+<tr>
+    <td><h1>kukurrukuku</h1></td>
+</tr>

--- a/Smarty/templates/modules/Accounts/LBL_DESCRIPTION_INFORMATION_edit.tpl
+++ b/Smarty/templates/modules/Accounts/LBL_DESCRIPTION_INFORMATION_edit.tpl
@@ -1,3 +1,0 @@
-<tr>
-    <td><h1>kukurrukuku</h1></td>
-</tr>

--- a/Smarty/templates/salesEditView.tpl
+++ b/Smarty/templates/salesEditView.tpl
@@ -191,8 +191,12 @@ function AddressSync(Addform,id)
 										{/if}
 										</tr>
 
-										<!-- Handle the ui types display -->
-										{include file="DisplayFields.tpl"}
+                                                                                {if $CUSTOMBLOCKS.$header.custom}
+                                                                                    {include file=$CUSTOMBLOCKS.$header.tpl}
+                                                                                {else}
+                                                                                    <!-- Handle the ui types display -->
+                                                                                    {include file="DisplayFields.tpl"}
+                                                                                {/if}
 
 									   {/foreach}
 

--- a/include/utils/CommonUtils.php
+++ b/include/utils/CommonUtils.php
@@ -1300,8 +1300,8 @@ function getCustomBlocks($module, $disp_view) {
 //                echo '<pre>';var_dump($disp_view,$disp_view == 'detail_view',file_exists("Smarty/templates/modules/$module/{$block_label[$blockid]}_display.tpl"),"Smarty/templates/modules/$module/{$block_label[$blockid]}_display.tpl");echo '</pre>';
                 if (($disp_view == 'edit_view' || $disp_view == 'create' || $disp_view == 'create_view') && file_exists("Smarty/templates/modules/$module/{$block_label[$blockid]}_edit.tpl")) {
                     $block_list[$sLabelVal] = array('custom' => true, 'tpl' => "modules/$module/{$block_label[$blockid]}_edit.tpl");
-                } elseif ($disp_view == 'detail_view' && file_exists("Smarty/templates/modules/$module/{$block_label[$blockid]}_display.tpl")) {
-                    $block_list[$sLabelVal] = array('custom' => true, 'tpl' => "modules/$module/{$block_label[$blockid]}_display.tpl");
+                } elseif ($disp_view == 'detail_view' && file_exists("Smarty/templates/modules/$module/{$block_label[$blockid]}_detail.tpl")) {
+                    $block_list[$sLabelVal] = array('custom' => true, 'tpl' => "modules/$module/{$block_label[$blockid]}_detail.tpl");
                 } else {
                     $block_list[$sLabelVal] = array('custom' => false, 'tpl' => '');
                 }

--- a/include/utils/CommonUtils.php
+++ b/include/utils/CommonUtils.php
@@ -1274,6 +1274,43 @@ function getBlocks($module, $disp_view, $mode, $col_fields = '', $info_type = ''
 }
 
 /**
+ * This function returns the customized vtiger_blocks and its template.
+ * Input Parameter are $module - module name, $disp_view = display view (edit,detail or create)
+ * This function returns an array
+ */
+function getCustomBlocks($module, $disp_view) {
+	global $log;
+	$log->debug("Entering getCustomBlocks(" . $module . "," . $disp_view . ") method ...");
+	global $adb, $current_user;
+	global $mod_strings;
+	$tabid = getTabid($module);
+	$block_detail = Array();
+	$getBlockinfo = "";
+	$query = "select blockid,blocklabel,show_title,display_status,iscustom from vtiger_blocks where tabid=? and $disp_view=0 and visible = 0 order by sequence";
+	$result = $adb->pquery($query, array($tabid));
+	$noofrows = $adb->num_rows($result);
+	$prev_header = "";
+	$block_list = array();
+	$block_label = array();
+	for ($i = 0; $i < $noofrows; $i++) {
+		$blockid = $adb->query_result($result, $i, "blockid");
+		$block_label[$blockid] = $adb->query_result($result, $i, "blocklabel");
+		$sLabelVal = getTranslatedString($block_label[$blockid], $module);
+		array_push($block_list, $sLabelVal);
+//                echo '<pre>';var_dump($disp_view,$disp_view == 'detail_view',file_exists("Smarty/templates/modules/$module/{$block_label[$blockid]}_display.tpl"),"Smarty/templates/modules/$module/{$block_label[$blockid]}_display.tpl");echo '</pre>';
+                if (($disp_view == 'edit_view' || $disp_view == 'create' || $disp_view == 'create_view') && file_exists("Smarty/templates/modules/$module/{$block_label[$blockid]}_edit.tpl")) {
+                    $block_list[$sLabelVal] = array('custom' => true, 'tpl' => "modules/$module/{$block_label[$blockid]}_edit.tpl");
+                } elseif ($disp_view == 'detail_view' && file_exists("Smarty/templates/modules/$module/{$block_label[$blockid]}_display.tpl")) {
+                    $block_list[$sLabelVal] = array('custom' => true, 'tpl' => "modules/$module/{$block_label[$blockid]}_display.tpl");
+                } else {
+                    $block_list[$sLabelVal] = array('custom' => false, 'tpl' => '');
+                }
+	}
+
+	return $block_list;
+}
+
+/**
  * This function is used to get the display type.
  * Takes the input parameter as $mode - edit  (mostly)
  * This returns string type value

--- a/modules/Accounts/DetailView.php
+++ b/modules/Accounts/DetailView.php
@@ -139,7 +139,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Assets/DetailView.php
+++ b/modules/Assets/DetailView.php
@@ -91,7 +91,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Campaigns/DetailView.php
+++ b/modules/Campaigns/DetailView.php
@@ -94,7 +94,12 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+//echo '<pre>';var_dump($focus->column_fields,$blocks,$custom_blocks);echo '</pre>';
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/CobroPago/DetailView.php
+++ b/modules/CobroPago/DetailView.php
@@ -91,7 +91,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Contacts/DetailView.php
+++ b/modules/Contacts/DetailView.php
@@ -157,7 +157,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Documents/DetailView.php
+++ b/modules/Documents/DetailView.php
@@ -75,7 +75,10 @@ $smarty->assign('FOLDERID',$folderid);
 $smarty->assign('DLD_PATH',$filepath);
 $smarty->assign('FILENAME', $filename);
 $allblocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
 $smarty->assign('BLOCKS', $allblocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 $flag = 0;
 foreach($allblocks as $blocks)
 {

--- a/modules/Faq/DetailView.php
+++ b/modules/Faq/DetailView.php
@@ -93,7 +93,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/GlobalVariable/DetailView.php
+++ b/modules/GlobalVariable/DetailView.php
@@ -91,7 +91,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/HelpDesk/DetailView.php
+++ b/modules/HelpDesk/DetailView.php
@@ -128,7 +128,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/InventoryDetails/DetailView.php
+++ b/modules/InventoryDetails/DetailView.php
@@ -91,7 +91,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Invoice/DetailView.php
+++ b/modules/Invoice/DetailView.php
@@ -100,7 +100,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Leads/DetailView.php
+++ b/modules/Leads/DetailView.php
@@ -156,7 +156,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes') {
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/ModComments/DetailView.php
+++ b/modules/ModComments/DetailView.php
@@ -89,7 +89,11 @@ if($singlepane_view == 'true') {
 $smarty->assign('EDIT_DUPLICATE', 'notpermitted');
 $smarty->assign('DELETE', 'notpermitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Potentials/DetailView.php
+++ b/modules/Potentials/DetailView.php
@@ -94,7 +94,11 @@ if(isPermitted('Invoice','CreateView',$_REQUEST['record']) == 'yes')
 	$smarty->assign('CONVERTINVOICE','permitted');
 $smarty->assign('CONVERTMODE','potentoinvoice');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/PriceBooks/DetailView.php
+++ b/modules/PriceBooks/DetailView.php
@@ -93,7 +93,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'DeletePriceBook', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Products/DetailView.php
+++ b/modules/Products/DetailView.php
@@ -109,7 +109,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Project/DetailView.php
+++ b/modules/Project/DetailView.php
@@ -91,7 +91,12 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+//echo '<pre>';var_dump($focus->column_fields,$blocks,$custom_blocks);echo '</pre>';
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Project/DetailView.php
+++ b/modules/Project/DetailView.php
@@ -93,7 +93,6 @@ if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 
 $blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
 $custom_blocks = getCustomBlocks($currentModule,'detail_view');
-//echo '<pre>';var_dump($focus->column_fields,$blocks,$custom_blocks);echo '</pre>';
 $smarty->assign('BLOCKS', $blocks);
 $smarty->assign('CUSTOMBLOCKS', $custom_blocks);
 $smarty->assign('FIELDS',$focus->column_fields);

--- a/modules/ProjectMilestone/DetailView.php
+++ b/modules/ProjectMilestone/DetailView.php
@@ -91,7 +91,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/ProjectTask/DetailView.php
+++ b/modules/ProjectTask/DetailView.php
@@ -91,7 +91,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/PurchaseOrder/DetailView.php
+++ b/modules/PurchaseOrder/DetailView.php
@@ -100,7 +100,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Quotes/DetailView.php
+++ b/modules/Quotes/DetailView.php
@@ -105,7 +105,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/SMSNotifier/DetailView.php
+++ b/modules/SMSNotifier/DetailView.php
@@ -97,8 +97,10 @@ $blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
 if(empty($blocks[getTranslatedString('StatusInformation', $currentModule)])) {
 	$blocks[getTranslatedString('StatusInformation', $currentModule)] = array();
 }
-
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
 $smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/SalesOrder/DetailView.php
+++ b/modules/SalesOrder/DetailView.php
@@ -103,7 +103,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/ServiceContracts/DetailView.php
+++ b/modules/ServiceContracts/DetailView.php
@@ -91,7 +91,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Services/DetailView.php
+++ b/modules/Services/DetailView.php
@@ -103,7 +103,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Vendors/DetailView.php
+++ b/modules/Vendors/DetailView.php
@@ -92,7 +92,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted('Vendors','Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/Vtiger/EditView.php
+++ b/modules/Vtiger/EditView.php
@@ -80,6 +80,11 @@ $disp_view = getView($focus->mode);
 $smarty->assign('BLOCKS', getBlocks($currentModule, $disp_view, $focus->mode, $focus->column_fields));
 $smarty->assign('BASBLOCKS', getBlocks($currentModule, $disp_view, $focus->mode, $focus->column_fields, 'BAS'));
 $smarty->assign('ADVBLOCKS',getBlocks($currentModule,$disp_view,$focus->mode,$focus->column_fields,'ADV'));
+
+$custom_blocks = getCustomBlocks($currentModule,$disp_view);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
+
 $smarty->assign('OP_MODE',$disp_view);
 $smarty->assign('APP', $app_strings);
 $smarty->assign('MOD', $mod_strings);

--- a/modules/cbMap/DetailView.php
+++ b/modules/cbMap/DetailView.php
@@ -91,7 +91,11 @@ if(isPermitted($currentModule, 'CreateView', $record) == 'yes')
 if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');

--- a/modules/cbupdater/DetailView.php
+++ b/modules/cbupdater/DetailView.php
@@ -92,7 +92,11 @@ if($singlepane_view == 'true') {
 // if(isPermitted($currentModule, 'Delete', $record) == 'yes')
 // 	$smarty->assign('DELETE', 'permitted');
 
-$smarty->assign('BLOCKS', getBlocks($currentModule,'detail_view','',$focus->column_fields));
+$blocks = getBlocks($currentModule,'detail_view','',$focus->column_fields);
+$custom_blocks = getCustomBlocks($currentModule,'detail_view');
+$smarty->assign('BLOCKS', $blocks);
+$smarty->assign('CUSTOMBLOCKS', $custom_blocks);
+$smarty->assign('FIELDS',$focus->column_fields);
 
 // Gather the custom link information to display
 include_once('vtlib/Vtiger/Link.php');


### PR DESCRIPTION
Add feature to customize module Blocks.
If *Smarty/templates/modules/MODULE/BLOCK_LABEL_detail.tpl* is present, overrides default detail block view, same for edit with *Smarty/templates/modules/MODULE/BLOCK_LABEL_edit.tpl*

MODULE is module name.
BLOCK_LABEL is the label of the block you want customize.

Note that is the developer job to recreate full structure for block, for that you can use $FIELDS array with crmobject->custom_fields in it, in the Smarty template.

Modules without DetailView.php script are'nt adapted, also:
- Email
- Users
- Calendar
- Webmails

Because it's DetailView.php script differs so much than default one.

Enjoy !