### PR TITLE
Better use of the language files when no records are found?

### DIFF
--- a/Smarty/templates/ListViewEntries.tpl
+++ b/Smarty/templates/ListViewEntries.tpl
@@ -162,12 +162,14 @@
 							<td style="border-bottom: 1px solid rgb(204, 204, 204);" nowrap="nowrap" width="75%">
 								<span class="genHeaderSmall">
 								{if $MODULE_CREATE eq 'SalesOrder' || $MODULE_CREATE eq 'PurchaseOrder' || $MODULE_CREATE eq 'Invoice' || $MODULE_CREATE eq 'Quotes'}
-									{$APP.LBL_NO} {$APP.$MODULE_CREATE} {$APP.LBL_FOUND} !
+									<!--{$APP.LBL_NO} {$APP.$MODULE_CREATE} {$APP.LBL_FOUND} !-->
+									{$APP.LBL_NO_RECORD}&nbsp;{$APP.LBL_FOUND}
 								{elseif $MODULE eq 'Calendar'}
 									{$APP.LBL_NO} {$APP.ACTIVITIES} {$APP.LBL_FOUND} !
 								{else}
 									{* vtlib customization: Use translation string only if available *}
-									{$APP.LBL_NO} {if $APP.$MODULE_CREATE}{$APP.$MODULE_CREATE}{else}{$MODULE_CREATE}{/if} {$APP.LBL_FOUND} !
+									<!--{$APP.LBL_NO} {if $APP.$MODULE_CREATE}{$APP.$MODULE_CREATE}{else}{$MODULE_CREATE}{/if} {$APP.LBL_FOUND} !-->
+									{$APP.LBL_NO_RECORD}&nbsp;{$APP.LBL_FOUND}
 								{/if}
 								</span>
 							</td>


### PR DESCRIPTION
This is a test that I'd like evaluated. The current behaviour leads to a very weird sentence in Dutch. I changed it so that it is more generic and makes sense in both English and Dutch ("No Records Found"). I know this would also work in German, but I have no idea how it would translate in Spanish, Italian etc.. Please let me know if this would be an improvement in these languages as well.