### PR TITLE
Inventory details tax block

### DIFF
--- a/build/changeSets/2018/inventoryDetailsTaxBlock.php
+++ b/build/changeSets/2018/inventoryDetailsTaxBlock.php
@@ -1,0 +1,102 @@
+<?php
+/*************************************************************************************************
+ * Copyright 2018 MajorLabel -- This file is a part of MajorLabel coreBOS Customizations.
+* Licensed under the vtiger CRM Public License Version 1.1 (the "License"); you may not use this
+* file except in compliance with the License. You can redistribute it and/or modify it
+* under the terms of the License. MajorLabel reserves all rights not expressly
+* granted by the License. coreBOS distributed by MajorLabel S.L. is distributed in
+* the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Unless required by
+* applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS, WITHOUT ANY WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the specific language governing
+* permissions and limitations under the License. You may obtain a copy of the License
+* at <http://corebos.org/documentation/doku.php?id=en:devel:vpl11>
+*************************************************************************************************/
+class inventoryDetailsTaxBlock extends cbupdaterWorker {
+	
+	function applyChange() {
+		if ($this->hasError()) $this->sendError();
+		if ($this->isApplied()) {
+			$this->sendMsg('Changeset '.get_class($this).' already applied!');
+		} else {
+			global $adb;
+
+			// Install new block and fields
+			require_once('vtlib/Vtiger/Module.php');
+			$mod = Vtiger_Module::getInstance('InventoryDetails');
+
+			$block = new Vtiger_Block();
+			$block->label = 'InventoryDetailsTaxBlock';
+			$block->sequence = 3;
+			$mod->addBlock($block);
+
+			$r = $adb->pquery('SELECT * FROM vtiger_inventorytaxinfo WHERE deleted=?', array(0));
+			while($tax=$adb->fetch_array($r)) {
+				$field = new Vtiger_Field();
+				$field->label = $tax['taxlabel'];
+				$field->name = 'id_tax' . $tax['taxid'] . '_perc';
+				$field->column = 'id_tax' . $tax['taxid'] . '_perc';
+				$field->columntype = 'DECIMAL(7,3)';
+				$field->uitype = 9;
+				$field->typeofdata = 'V~O';
+				$block->addField($field);
+			}
+
+			// Install event handler for when taxes are created, changed and renamed
+			require_once('include/events/include.inc');
+			$em = new VTEventsManager($adb);
+			$eventName = 'corebos.add.tax';
+			$fileName = 'modules/InventoryDetails/taxHandler.php';
+			$className = 'addTaxHandler';
+			$em->registerHandler($eventName, $fileName, $className);
+
+			$eventName = 'corebos.changestatus.tax';
+			$fileName = 'modules/InventoryDetails/taxHandler.php';
+			$className = 'changeStatusTaxHandler';
+			$em->registerHandler($eventName, $fileName, $className);
+
+			$eventName = 'corebos.changelabel.tax';
+			$fileName = 'modules/InventoryDetails/taxHandler.php';
+			$className = 'changeLabelTaxHandler';
+			$em->registerHandler($eventName, $fileName, $className);
+
+			$this->markApplied();
+		}
+		$this->finishExecution();
+	}
+	
+	function undoChange() {
+		if ($this->hasError()) $this->sendError();
+		if ($this->isApplied()) {
+			global $adb;
+			require_once('vtlib/Vtiger/Module.php');
+
+			$mod = Vtiger_Module::getInstance('InventoryDetails');
+			$block = Vtiger_Block::getInstance('InventoryDetailsTaxBlock', $mod);
+			$block->delete(true);
+
+			// Remove the registered events
+			require_once('include/events/include.inc');
+			$em = new VTEventsManager($adb);
+			$em->unregisterHandler('addTaxHandler');
+			$em->unregisterHandler('changeStatusTaxHandler');
+			$em->unregisterHandler('changeLabelTaxHandler');
+
+			$this->markUndone(false);
+
+		} else {
+			$this->sendMsg('Changeset '.get_class($this).' not applied, it cannot be undone!');
+		}
+		$this->finishExecution();
+	}
+	
+	function isApplied() {
+		$done = parent::isApplied();
+		if (!$done) {
+
+		}
+		return $done;
+	}
+	
+}

--- a/modules/InventoryDetails/language/de_de.lang.php
+++ b/modules/InventoryDetails/language/de_de.lang.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  ************************************************************************************/
 
-$mod_strings = array(
+$mod_strings = Array(
 	'InventoryDetails' => 'Inventory Details',
 	'SINGLE_InventoryDetails' => 'Inventory Details',
 	'InventoryDetails ID' => 'Inventory Details ID',
@@ -36,5 +36,7 @@ $mod_strings = array(
 	'Line Completed' => 'Line Completed',
 	'Total Stock' => 'Total Stock',
 	'Description' => 'Description',
+	'InventoryDetailsTaxBlock' => 'Steuer'
 );
+
 ?>

--- a/modules/InventoryDetails/language/en_gb.lang.php
+++ b/modules/InventoryDetails/language/en_gb.lang.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  ************************************************************************************/
 
-$mod_strings = array(
+$mod_strings = Array(
 	'InventoryDetails' => 'Inventory Details',
 	'SINGLE_InventoryDetails' => 'Inventory Details',
 	'InventoryDetails ID' => 'Inventory Details ID',
@@ -36,5 +36,7 @@ $mod_strings = array(
 	'Line Completed' => 'Line Completed',
 	'Total Stock' => 'Total Stock',
 	'Description' => 'Description',
+	'InventoryDetailsTaxBlock' => 'Taxes'
 );
+
 ?>

--- a/modules/InventoryDetails/language/en_us.lang.php
+++ b/modules/InventoryDetails/language/en_us.lang.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  ************************************************************************************/
 
-$mod_strings = array(
+$mod_strings = Array(
 	'InventoryDetails' => 'Inventory Details',
 	'SINGLE_InventoryDetails' => 'Inventory Details',
 	'InventoryDetails ID' => 'Inventory Details ID',
@@ -36,5 +36,7 @@ $mod_strings = array(
 	'Line Completed' => 'Line Completed',
 	'Total Stock' => 'Total Stock',
 	'Description' => 'Description',
+	'InventoryDetailsTaxBlock' => 'Taxes'
 );
+
 ?>

--- a/modules/InventoryDetails/language/es_es.lang.php
+++ b/modules/InventoryDetails/language/es_es.lang.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  ************************************************************************************/
 
-$mod_strings = array(
+$mod_strings = Array(
 	'InventoryDetails' => 'Detalle de Inventario',
 	'SINGLE_InventoryDetails' => 'Detalle de Inventario',
 	'InventoryDetails ID' => 'Detalle Inventario ID',
@@ -36,5 +36,8 @@ $mod_strings = array(
 	'Line Completed' => 'Línea Completada',
 	'Total Stock' => 'Total Stock',
 	'Description' => 'Descripción',
+	'InventoryDetailsTaxBlock' => 'Impuesto'
+
 );
+
 ?>

--- a/modules/InventoryDetails/language/es_mx.lang.php
+++ b/modules/InventoryDetails/language/es_mx.lang.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  ************************************************************************************/
 
-$mod_strings = array(
+$mod_strings = Array(
 	'InventoryDetails' => 'Detalle de Inventario',
 	'SINGLE_InventoryDetails' => 'Detalle de Inventario',
 	'InventoryDetails ID' => 'Detalle Inventario ID',
@@ -36,5 +36,8 @@ $mod_strings = array(
 	'Line Completed' => 'Línea Completada',
 	'Total Stock' => 'Total Stock',
 	'Description' => 'Descripción',
+	'InventoryDetailsTaxBlock' => 'Impuesto'
+
 );
+
 ?>

--- a/modules/InventoryDetails/language/fr_fr.lang.php
+++ b/modules/InventoryDetails/language/fr_fr.lang.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  ************************************************************************************/
 
-$mod_strings = array(
+$mod_strings = Array(
 	'InventoryDetails' => 'Détails Inventaire',
 	'SINGLE_InventoryDetails' => 'Détails Inventaire',
 	'InventoryDetails ID' => 'Détails Inventaire ID',
@@ -36,5 +36,7 @@ $mod_strings = array(
 	'Line Completed' => 'Ligne complété',
 	'Total Stock' => 'Stock total',
 	'Description' => 'Description',
+	'InventoryDetailsTaxBlock' => 'Impôt'
 );
+
 ?>

--- a/modules/InventoryDetails/language/hu_hu.lang.php
+++ b/modules/InventoryDetails/language/hu_hu.lang.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  ************************************************************************************/
 
-$mod_strings = array(
+$mod_strings = Array(
 	'InventoryDetails' => 'Inventory Details',
 	'SINGLE_InventoryDetails' => 'Inventory Details',
 	'InventoryDetails ID' => 'Inventory Details ID',
@@ -36,5 +36,7 @@ $mod_strings = array(
 	'Line Completed' => 'Line Completed',
 	'Total Stock' => 'Total Stock',
 	'Description' => 'Description',
+	'InventoryDetailsTaxBlock' => 'Adó'
 );
+
 ?>

--- a/modules/InventoryDetails/language/it_it.lang.php
+++ b/modules/InventoryDetails/language/it_it.lang.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  ************************************************************************************/
 
-$mod_strings = array(
+$mod_strings = Array(
 	'InventoryDetails' => 'Dettagli Inventario',
 	'SINGLE_InventoryDetails' => 'Dettagli Inventario',
 	'InventoryDetails ID' => 'ID Dettagli Inventario',
@@ -36,5 +36,7 @@ $mod_strings = array(
 	'Line Completed' => 'Linea completata',
 	'Total Stock' => 'Stock Totale',
 	'Description' => 'Descrizione',
+	'InventoryDetailsTaxBlock' => 'Imposta'
 );
+
 ?>

--- a/modules/InventoryDetails/language/nl_nl.lang.php
+++ b/modules/InventoryDetails/language/nl_nl.lang.php
@@ -34,5 +34,6 @@ $mod_strings = array(
 	'Description' => 'Beschrijving',
 	'Inventory Details No' => 'Voorraad details nummer',
 	'Total Stock' => 'Total Stock',
+	'InventoryDetailsTaxBlock' => 'Belastingen'
 );
 ?>

--- a/modules/InventoryDetails/language/pt_br.lang.php
+++ b/modules/InventoryDetails/language/pt_br.lang.php
@@ -8,7 +8,7 @@
  * All Rights Reserved.
  ************************************************************************************/
 
-$mod_strings = array(
+$mod_strings = Array(
 	'InventoryDetails' => 'Inventory Details',
 	'SINGLE_InventoryDetails' => 'Inventory Details',
 	'InventoryDetails ID' => 'Inventory Details ID',
@@ -36,5 +36,7 @@ $mod_strings = array(
 	'Line Completed' => 'Line Completed',
 	'Total Stock' => 'Total Stock',
 	'Description' => 'Description',
+	'InventoryDetailsTaxBlock' => 'Imposto'
 );
+
 ?>

--- a/modules/InventoryDetails/taxHandler.php
+++ b/modules/InventoryDetails/taxHandler.php
@@ -1,0 +1,87 @@
+<?php
+/*************************************************************************************************
+ * Copyright 2018 MajorLabel -- This file is a part of MajorLabel coreBOS Customizations.
+* Licensed under the vtiger CRM Public License Version 1.1 (the "License"); you may not use this
+* file except in compliance with the License. You can redistribute it and/or modify it
+* under the terms of the License. MajorLabel reserves all rights not expressly
+* granted by the License. coreBOS distributed by MajorLabel S.L. is distributed in
+* the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Unless required by
+* applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS, WITHOUT ANY WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the specific language governing
+* permissions and limitations under the License. You may obtain a copy of the License
+* at <http://corebos.org/documentation/doku.php?id=en:devel:vpl11>
+*************************************************************************************************/
+Class addTaxHandler extends VTEventHandler {
+
+	public function handleEvent($eventName, $eventData){
+
+		if ($eventData['tax_type'] == 'tax') {
+			global $adb;
+			require_once('vtlib/Vtiger/Module.php');
+
+			$mod = Vtiger_Module::getInstance('InventoryDetails');
+			$block = Vtiger_Block::getInstance('InventoryDetailsTaxBlock', $mod);
+
+			$field = new Vtiger_Field();
+			$field->label = $eventData['tax_label'];
+			$field->name = 'id_tax' . $eventData['tax_id'] . '_perc';
+			$field->column = 'id_tax' . $eventData['tax_id'] . '_perc';
+			$field->columntype = 'DECIMAL(7,3)';
+			$field->uitype = 9;
+			$field->typeofdata = 'V~O';
+			$block->addField($field);
+		}
+
+	}
+
+}
+
+Class changeStatusTaxHandler extends VTEventHandler {
+
+	public function handleEvent($eventName, $eventData) {
+
+		if ($eventData['tax_type'] == 'tax') {
+			global $adb;
+			require_once('vtlib/Vtiger/Module.php');
+
+			$r = $adb->pquery('SELECT taxid FROM vtiger_inventorytaxinfo WHERE taxname = ?', array($eventData['tax_name']));
+			$taxid = $adb->query_result($r, 0, 'taxid');
+			$fieldname = 'id_tax' . $taxid . '_perc';
+
+			$mod = Vtiger_Module::getInstance('InventoryDetails');
+			$field = Vtiger_Field::getInstance($fieldname, $mod);
+			$field->presence = $eventData['status'] == 'disabled' ? 1 : 2;
+			$field->save();
+		}
+
+	}
+
+}
+
+Class changeLabelTaxHandler extends VTEventHandler {
+
+	public function handleEvent($eventName, $eventData) {
+
+		if ($eventData['tax_type'] == 'tax') {
+			global $adb;
+			require_once('vtlib/Vtiger/Module.php');
+
+			$r = $adb->pquery('SELECT taxid FROM vtiger_inventorytaxinfo WHERE taxlabel = ?', array($eventData['new_label']));
+			$taxid = $adb->query_result($r, 0, 'taxid');
+			$fieldname = 'id_tax' . $taxid . '_perc';
+
+			$r = $adb->pquery('SELECT presence FROM vtiger_field WHERE fieldname = ?', array($fieldname));
+			$presence = $adb->query_result($r, 0, 'presence');
+
+			$mod = Vtiger_Module::getInstance('InventoryDetails');
+			$field = Vtiger_Field::getInstance($fieldname, $mod);
+			$field->label = $eventData['new_label'];
+			$field->presence = $presence;
+			$field->save();
+		}
+
+	}
+
+}

--- a/modules/Settings/TaxConfig.php
+++ b/modules/Settings/TaxConfig.php
@@ -170,6 +170,13 @@ function updateTaxLabels($new_labels, $sh='')
 			else
 				$query = "update vtiger_inventorytaxinfo set taxlabel = ? where taxid=?";
 			$adb->pquery($query, array($new_val, $taxid));
+
+			$event_data = array(
+				'tax_type' => $sh == 'sh' ? 'sh' : 'tax',
+				'tax_id' => $taxid,
+				'new_label' => $new_val
+			);
+			cbEventHandler::do_action('corebos.changelabel.tax',$event_data);
 		}
 	}
 	if($duplicateTaxLabels > 0) {
@@ -262,10 +269,17 @@ function changeDeleted($taxname, $deleted, $sh='')
 	global $log, $adb;
 	$log->debug("Entering into function changeDeleted($taxname, $deleted, $sh)");
 
-	if($sh == 'sh')
+	if($sh == 'sh') {
 		$adb->pquery("update vtiger_shippingtaxinfo set deleted=? where taxname=?", array($deleted, $taxname));
-	else
+	} else {
 		$adb->pquery("update vtiger_inventorytaxinfo set deleted=? where taxname=?", array($deleted, $taxname));
+	}
+	$event_data = array(
+		'tax_type' => $sh == 'sh' ? 'sh' : 'tax',
+		'tax_name' => $taxname,
+		'status' => $deleted == 1 ? 'disabled' : 'enabled'
+	);
+	cbEventHandler::do_action('corebos.changestatus.tax',$event_data);
 	$log->debug("Exit from function changeDeleted($taxname, $deleted, $sh)");
 }
 

--- a/modules/cbupdater/cbupdates/inventory_details_taxblock_update.xml
+++ b/modules/cbupdater/cbupdates/inventory_details_taxblock_update.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<updatesChangeLog>
+<changeSet>
+	<author>MajorLabel</author>
+	<description>Installs a new block in InventoryDetails module for separate taxes</description>
+	<filename>build/changeSets/2018/inventoryDetailsTaxBlock.php</filename>
+	<classname>inventoryDetailsTaxBlock</classname>
+	<systemupdate>false</systemupdate>
+</changeSet>
+</updatesChangeLog>


### PR DESCRIPTION
Sorry, started a new PR becuase the old one was getting messy and cluttered with typo-commits.

As far as the if clause for the modules checking, I'm not sure if I agree there. I know that you're supposed to use that format when registering handlers that listen to records being saved, deleted and such. But these handlers don't fire on every record, or even on any record for that matter. They fire on adding a tax, updating a tax label and enabling/disabling a tax. So there really isn't a module to check on (besides 'Settings' maybe). I didn't configure the events to fire on record editing/saving. Or am I wrong here and do ALL events fire on modules ALWAYS, even the ones I created, even though they don't live in module-code? In which case, should I check on the module name 'Settings'?