### PR TITLE
feat(cbMap) Allow multiple validation of the same type on one field

### DIFF
--- a/modules/cbMap/processmap/Validations.php
+++ b/modules/cbMap/processmap/Validations.php
@@ -131,10 +131,12 @@ class Validations extends processcbMap {
 			$fl = $adb->pquery('select fieldlabel from vtiger_field where tabid=? and columnname=?', array($tabid,$valfield));
 			$fieldlabel = $adb->query_result($fl, 0, 0);
 			$i18n = getTranslatedString($fieldlabel, $mapping['origin']);
-			foreach ($vals as $rule => $restrictions) {
+			foreach ($vals as $val) {
 				if (isset($screen_values['action']) && $screen_values['action']=='MassEditSave' && empty($screen_values[$valfield.'_mass_edit_check'])) {
 					continue; // we are not saving this field in mass edit save so we don't have to check it
 				}
+				$rule = $val['rule'];
+				$restrictions = $val['rst'];
 				switch ($rule) {
 					case 'required':
 					case 'accepted':
@@ -241,7 +243,8 @@ class Validations extends processcbMap {
 			}
 			$allvals=array();
 			foreach ($v->validations->validation as $val) {
-				$rule = (String)$val->rule;
+				$retval = array();
+				$retval['rule'] = (String)$val->rule;
 				if (empty($rule)) {
 					continue;
 				}
@@ -251,7 +254,8 @@ class Validations extends processcbMap {
 						$rst[]=(String)$rv;
 					}
 				}
-				$allvals[$rule]=$rst;
+				$retval['rst'] = $rst;
+				$allvals[]=$retval;
 			}
 			$val_fields[$fieldname] = $allvals;
 		}

--- a/modules/cbMap/processmap/Validations.php
+++ b/modules/cbMap/processmap/Validations.php
@@ -245,7 +245,7 @@ class Validations extends processcbMap {
 			foreach ($v->validations->validation as $val) {
 				$retval = array();
 				$retval['rule'] = (String)$val->rule;
-				if (empty($rule)) {
+				if (empty($retval['rule'])) {
 					continue;
 				}
 				$rst = array();


### PR DESCRIPTION
Previously, if you would apply multiple rules of the same type (e.g. 'custom' on the same field), only the last one would apply. With these changes you could use more than one (especially helpful when using custom rules) validation of the same type on one field.