### PR TITLE
feat(Webservice) Allow WS clients to send DB formatted productline cu…

### DIFF
--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -628,9 +628,11 @@ class CRMEntity {
 
 			$ajaxSave = false;
 			if ((isset($_REQUEST['file']) && $_REQUEST['file'] == 'DetailViewAjax' && isset($_REQUEST['ajxaction']) && $_REQUEST['ajxaction'] == 'DETAILVIEW'
-						&& isset($_REQUEST["fldName"]) && $_REQUEST["fldName"] != $fieldname)
-					|| (isset($_REQUEST['action']) && $_REQUEST['action'] == 'MassEditSave' && !isset($_REQUEST[$fieldname."_mass_edit_check"])
-							&& (!isset($_REQUEST['ajxaction']) || $_REQUEST['ajxaction'] != 'Workflow'))) {
+				&& isset($_REQUEST["fldName"]) && $_REQUEST["fldName"] != $fieldname)
+				|| (isset($_REQUEST['action']) && $_REQUEST['action'] == 'MassEditSave' && !isset($_REQUEST[$fieldname."_mass_edit_check"])
+				&& (!isset($_REQUEST['ajxaction']) || $_REQUEST['ajxaction'] != 'Workflow'))
+				|| (!empty($this->column_fields['__cbws_skipcurdbconv'.$fieldname]) || !empty($this->column_fields['__cbws_skipcurdbconvall'])))
+			{
 				$ajaxSave = true;
 			}
 

--- a/include/Webservices/ProductLines.php
+++ b/include/Webservices/ProductLines.php
@@ -33,7 +33,7 @@ $subtotal = 0;
 $totalwithtax = 0;
 $i = 0;
 $pdoInformation=$element['pdoInformation'];
-$skipCurDBConv = (isset($element['__cbws_skipcurdbconv']) && ($element['__cbws_skipcurdbconv'] == 'true')) ? true : false;
+$skipCurDBConv = (isset($element['__cbws_skipcurdbconv_pdo']) && (!empty($element['__cbws_skipcurdbconv_pdo'])) ? true : false;
 foreach ($pdoInformation as $pdoline) {
 	$i++;
 	$_REQUEST['deleted'.$i]=(isset($pdoline['deleted']) ? $pdoline['deleted'] : 0);

--- a/include/Webservices/ProductLines.php
+++ b/include/Webservices/ProductLines.php
@@ -33,6 +33,7 @@ $subtotal = 0;
 $totalwithtax = 0;
 $i = 0;
 $pdoInformation=$element['pdoInformation'];
+$skipCurDBConv = (isset($element['__cbws_skipcurdbconv']) && ($element['__cbws_skipcurdbconv'] == 'true')) ? true : false;
 foreach ($pdoInformation as $pdoline) {
 	$i++;
 	$_REQUEST['deleted'.$i]=(isset($pdoline['deleted']) ? $pdoline['deleted'] : 0);
@@ -44,13 +45,13 @@ foreach ($pdoInformation as $pdoline) {
 	$qty=$pdoline['qty'];
 	$_REQUEST['qty'.$i]=$qty;
 	$setype=getSalesEntityType($pdoline['productid']);
-	$_REQUEST['listPrice'.$i] = CurrencyField::convertToDBFormat($pdoline['listprice']);
+	$_REQUEST['listPrice'.$i] = $skipCurDBConv == true ? $pdoline['listprice'] : CurrencyField::convertToDBFormat($pdoline['listprice']);
 	$discount=0;
 	if (!empty($pdoline['discount'])) {
 		$_REQUEST["discount$i"]='on';
 		$_REQUEST["discount_type$i"]=$pdoline['discount_type'];
 		if ($pdoline['discount_type']=='amount') {
-			$_REQUEST["discount_amount$i"] = CurrencyField::convertToDBFormat($pdoline['discount_amount']);
+			$_REQUEST["discount_amount$i"] = $skipCurDBConv == true ? $pdoline['discount_amount'] : CurrencyField::convertToDBFormat($pdoline['discount_amount']);
 			$discount=$pdoline['discount_amount'];
 		} else {
 			$_REQUEST["discount_percentage$i"]=$pdoline['discount_percentage'];


### PR DESCRIPTION
…rrencies

The purpose of this PR is to allow WS clients to insert a 'special' hidden field called '__cbws_skipcurdbconv'. When set to 'true', it will force the webservice update and revise methods to **not** use currency conversion to DB format. In other words, it allows the client to send DB formatted values without having to worry about them being multiplied by a million.