### PR TITLE
fix(MassEdit) Replacing empty action value with MassEditSave

### DIFF
--- a/modules/Vtiger/MassEditSave.php
+++ b/modules/Vtiger/MassEditSave.php
@@ -43,6 +43,10 @@ if (isset($params['start']) && $params['start']!='') {
 $exists = executefunctionsvalidate('ValidationExists', $currentModule);
 if (isset($idlist)) {
 	$_REQUEST['action'] = 'MassEditSave';
+
+	// Replacing params action value
+	$_REQUEST['params'] = preg_replace('/"action":""/', '"action":"MassEditSave"', $_REQUEST['params']);
+
 	$recordids = explode(';', $idlist);
 	$recordcount = count($recordids)-1;
 	$id = 1;
@@ -84,9 +88,6 @@ if (isset($idlist)) {
 			list($saveerror,$errormessage,$error_action,$returnvalues) = $focus->preSaveCheck($params);
 			if (!$saveerror) { // if there is an error we ignore this record
 				if ($exists == 'yes') {
-					// Replacing action value
-					$_REQUEST['params'] = preg_replace('/"action":""/', '"action":"MassEditSave"', $_REQUEST['params']);
-					
 					$validation = executefunctionsvalidate('ValidationLoad', $currentModule, vtlib_purify($_REQUEST['params']));
 					if ($validation == '%%%OK%%%') {
 						$msg = $app_strings['record'].' '.$recordid.' '.$app_strings['saved'];

--- a/modules/Vtiger/MassEditSave.php
+++ b/modules/Vtiger/MassEditSave.php
@@ -84,6 +84,9 @@ if (isset($idlist)) {
 			list($saveerror,$errormessage,$error_action,$returnvalues) = $focus->preSaveCheck($params);
 			if (!$saveerror) { // if there is an error we ignore this record
 				if ($exists == 'yes') {
+					// Replacing action value
+					$_REQUEST['params'] = preg_replace('/"action":""/', '"action":"MassEditSave"', $_REQUEST['params']);
+					
 					$validation = executefunctionsvalidate('ValidationLoad', $currentModule, vtlib_purify($_REQUEST['params']));
 					if ($validation == '%%%OK%%%') {
 						$msg = $app_strings['record'].' '.$recordid.' '.$app_strings['saved'];


### PR DESCRIPTION
Replacing the empty or blank `action:""` variable with `action:"MassEditSave"`