### PR TITLE
fix(MassEdit) Optimizing idlist

### DIFF
--- a/modules/Vtiger/MassEditSave.php
+++ b/modules/Vtiger/MassEditSave.php
@@ -24,13 +24,12 @@ function send_message($id, $message, $progress, $processed, $total) {
 	flush();
 }
 $params = json_decode(vtlib_purify($_REQUEST['params']), true);
-$params['massedit_recordids'] = coreBOS_Settings::getSetting('masseditids'.$params['corebos_browsertabID'], null);
 global $currentModule, $rstart;
 $nonSupportedMassEdit = array('Emails');
 
 $focus = CRMEntity::getInstance($currentModule);
 
-$idlist= vtlib_purify($params['massedit_recordids']);
+$idlist = vtlib_purify(coreBOS_Settings::getSetting('masseditids'.$params['corebos_browsertabID'], null));
 $viewid = isset($params['viewname']) ? vtlib_purify($params['viewname']) : '';
 $return_module = urlencode(vtlib_purify($params['massedit_module']));
 $return_action = 'index';


### PR DESCRIPTION
Removing unnecessary array `$params['massedit_recordids']`