### PR TITLE
Using all generated IDs on Delete Related Task

### DIFF
--- a/modules/com_vtiger_workflow/tasks/CBDeleteRelatedTask.inc
+++ b/modules/com_vtiger_workflow/tasks/CBDeleteRelatedTask.inc
@@ -48,7 +48,6 @@ class CBDeleteRelatedTask extends VTTask {
 		}
 		if ($businessMap == 'Condition Query') {
 			$ids = $focus->ConditionQuery($masterRecord);
-			$ids = $ids[0];
 		}
 
 		// Checking relation


### PR DESCRIPTION
To use all IDs generated by Condition Query method.