### PR TITLE
feat(Inventory) Permit fine-tuning the fields to search in for P/S au…

### DIFF
--- a/include/Webservices/CustomerPortalWS.php
+++ b/include/Webservices/CustomerPortalWS.php
@@ -970,6 +970,7 @@ function getProductServiceAutocomplete($term, $returnfields = array(), $limit = 
 		    vtiger_products.unit_price AS unit_price 
 		    FROM vtiger_products 
 			INNER JOIN vtiger_crmentity ON vtiger_products.productid = vtiger_crmentity.crmid 
+			INNER JOIN vtiger_productcf ON vtiger_products.productid = vtiger_productcf.productid 
 			".getNonAdminAccessControlQuery('Products', $current_user)."
 			WHERE ({$productsearchquery}) 
 			{$prodcondquery} 
@@ -989,6 +990,7 @@ function getProductServiceAutocomplete($term, $returnfields = array(), $limit = 
 		    vtiger_service.unit_price AS unit_price 
 		    FROM vtiger_service 
 			INNER JOIN vtiger_crmentity ON vtiger_service.serviceid = vtiger_crmentity.crmid 
+			INNER JOIN vtiger_servicecf ON vtiger_service.serviceid = vtiger_servicecf.serviceid 
 			".getNonAdminAccessControlQuery('Services', $current_user)."
 			WHERE ({$servicesearchquery}) 
 			{$servcondquery} 

--- a/include/Webservices/CustomerPortalWS.php
+++ b/include/Webservices/CustomerPortalWS.php
@@ -893,7 +893,7 @@ function getProductServiceAutocomplete($term, $returnfields = array(), $limit = 
 	$sourceModule = $adb->sql_escape_string(vtlib_purify($_REQUEST['sourceModule']));
 
 	$bmapname = $sourceModule . '_FieldInfo';
-	$cbMapid = GlobalVariable::getVariable('BusinessMapping_' . $bmapname, cbMap::getMapIdByName($bmapname));
+	$cbMapid = GlobalVariable::getVariable('BusinessMapping_FieldInfo', cbMap::getMapIdByName($bmapname), $sourceModule, $current_user->id);
 	$productsearchfields = array('productname','mfr_part_no','vendor_part_no');
 	$servicesearchfields = array('servicename');
 	$productsearchquery = '';

--- a/include/Webservices/CustomerPortalWS.php
+++ b/include/Webservices/CustomerPortalWS.php
@@ -902,6 +902,7 @@ function getProductServiceAutocomplete($term, $returnfields = array(), $limit = 
 	$servconds = array();
 	$prodcondquery = '';
 	$servcondquery = '';
+	$opmap = array('equals' => '=','smaller'=>'<','greater'=>'>');
 
 	require_once 'include/fields/CurrencyField.php';
 	require_once 'include/utils/CommonUtils.php';
@@ -936,9 +937,10 @@ function getProductServiceAutocomplete($term, $returnfields = array(), $limit = 
 	}
 
 	$prodcondquery .= count($prodconds) > 0 ? 'AND (' : '';
-	for ($i=0; $i < count($prodconds); $i++) {
+	for ($i=0; $i < count($prodconds); $i++) { 
 		if ($i % 2 == 0) {
-			$prodcondquery .= substr($prodconds[$i], 0, 3) == 'cf_' ? 'vtiger_productcf.'.$prodconds[$i] : 'vtiger_products.'.$prodconds[$i];
+			$prodcondoperation = $prodconds[$i]['field'] . ' ' . $opmap[$prodconds[$i]['operator']] . ' ' . $prodconds[$i]['value'];
+			$prodcondquery .= substr($prodconds[$i], 0, 3) == 'cf_' ? 'vtiger_productcf.'.$prodcondoperation : 'vtiger_products.'.$prodcondoperation;
 		} else {
 			$prodcondquery .= ' ' . $prodconds[$i] . ' ';
 		}
@@ -946,9 +948,10 @@ function getProductServiceAutocomplete($term, $returnfields = array(), $limit = 
 	$prodcondquery .= count($prodconds) > 0 ? ')' : '';
 
 	$servcondquery .= count($servconds) > 0 ? 'AND (' : '';
-	for ($i=0; $i < count($servconds); $i++) {
+	for ($i=0; $i < count($servconds); $i++) { 
 		if ($i % 2 == 0) {
-			$servcondquery .= substr($servconds[$i], 0, 3) == 'cf_' ? 'vtiger_servicecf.'.$servconds[$i] : 'vtiger_service.'.$servconds[$i];
+			$servcondoperation = $servconds[$i]['field'] . ' ' . $opmap[$servconds[$i]['operator']] . ' ' . $servconds[$i]['value'];
+			$servcondquery .= substr($servconds[$i], 0, 3) == 'cf_' ? 'vtiger_servicecf.'.$servcondoperation : 'vtiger_service.'.$servcondoperation;
 		} else {
 			$servcondquery .= ' ' . $servconds[$i] . ' ';
 		}

--- a/include/js/Inventory.js
+++ b/include/js/Inventory.js
@@ -1383,7 +1383,7 @@ function InventorySelectAll(mod, image_pth) {
 		this.specialKeys = ['up', 'down', 'esc', 'enter'],
 		this.threshold = 3,
 		this.input = el.getElementsByTagName('input')[0],
-		this.source = 'index.php?module=Utilities&action=UtilitiesAjax&file=ExecuteFunctions&functiontocall=getProductServiceAutocomplete&limit=10&term=',
+		this.source = 'index.php?module=Utilities&sourceModule='+gVTModule+'&action=UtilitiesAjax&file=ExecuteFunctions&functiontocall=getProductServiceAutocomplete&limit=10&term=',
 		this.active = false,
 		this.resultContainer,
 		this.resultBox,


### PR DESCRIPTION
…tocomplete

The first commit allows you to, for instance create a BusinessMap called 'Quotes_FieldInfo' that looks like this:
```
<map>
    <originmodule>
        <originname>Quotes</originname>
    </originmodule>
    <fields>
        <field>
            <fieldname>cbProductServiceField</fieldname>
            <features>
                <feature>
                    <name>searchfields</name>
                    <values>
                        <value>
                            <module>Products</module>
                            <value>productname,mfr_part_no,vendor_part_no,product_no</value>
                        </value>
                        <value>
                            <module>Service</module>
                            <value>servicename,service_no</value>
                        </value>
                    </values>
                </feature>
            </features>
        </field>
    </fields>
</map>
```
Where the 'special' fieldname 'cbProductServiceField' controls the options for the autocomplete. By default **nothing will change**, only when you create a BusinessMap will the override start.