### PR TITLE
fix(ModuleUpdate) Make 'import_Field' public since PackageUpdate refe…

### DIFF
--- a/vtlib/Vtiger/PackageImport.php
+++ b/vtlib/Vtiger/PackageImport.php
@@ -586,9 +586,9 @@ class Vtiger_PackageImport extends Vtiger_PackageExport {
 
 	/**
 	 * Import Field of the module
-	 * @access private
+	 * @access public
 	 */
-	private function import_Field($blocknode, $blockInstance, $moduleInstance, $fieldnode) {
+	public function import_Field($blocknode, $blockInstance, $moduleInstance, $fieldnode) {
 		$fieldInstance = new Vtiger_Field();
 		$fieldInstance->name         = $fieldnode->fieldname;
 		$fieldInstance->label        = $fieldnode->fieldlabel;


### PR DESCRIPTION
…rences it

I had a problem adding fields through the manifest file doing a module update because this method needs to be called outside of its class.