### PR TITLE
i18n(cbtranslation) Update getLanguage with Dutch

### DIFF
--- a/modules/cbtranslation/number2string.php
+++ b/modules/cbtranslation/number2string.php
@@ -157,6 +157,37 @@ class number2string {
 				'million' => 'MILLION',
 				'millions' => 'MILLIONS',
 			),
+			'nl' => array(
+				'coma' => 'punt',
+				'and' => 'en',
+				'one' => 'EEN',
+				'uni' => array(
+					'',
+					'EEN', 'TWEE', 'DRIE', 'VIER',
+					'VIJF', 'ZES', 'ZEVEN', 'ACHT',
+					'NEGEN', 'TIEN', 'ELF', 'TWAALF',
+					'DERTIEN', 'VEERTIEN', 'VIJFTIEN', 'ZESTIEN',
+					'ZEVENTIEN', 'ACHTTIEN', 'NEGENTIEN', 'TWINTIG',
+					'EENENTWINTIG', 'TWEEËNTWINTIG', 'DRIEËNTWINTIG', 'VIERENTWINTIG',
+					'VIJFENTWINTIG', 'ZESENTWINTIG', 'ZEVENENTWINTIG', 'ACHTENTWINTIG', 'NEGENENTWINTIG'
+				),
+				'dec' => array(
+					'', '', '',
+					'DERTIG', 'VEERTIG', 'VIJFTIG',
+					'ZESTIG', 'ZEVENTIG', 'TACHTIG', 'NEGENTIG'
+				),
+				'cent' => array(
+					'',
+					'HONDERD', 'TWEEHONDERD', 'DRIEHONDERD',
+					'VIERHONDERD', 'VIJFHONDERD', 'ZESHONDERD', 'ZEVENHONDERD',
+					'ACHTHONDERD', 'NEGENHONDERD'
+				),
+				'zero' => 'NUL',
+				'hundred' => 'HONDERD',
+				'thousand' => 'DUIZEND',
+				'million' => 'MILJOEN',
+				'millions' => 'MILJOEN',
+			),
 			'it' => array(
 				'coma' => 'punto',
 				'and' => '',


### PR DESCRIPTION
I suppose you want to use both single and plural 'million' in something like '1 million' or '2 million'? In that case in Dutch it doesn't make a difference. In something like 'Millions of dollars' though, it does. Let me know which one is the actual use case.