### PR TITLE
feat(Workflow) Add cond to check if parent has this as only child

### DIFF
--- a/include/js/de_de.lang.js
+++ b/include/js/de_de.lang.js
@@ -419,5 +419,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Fehler bei der Massenbearbeitung',
 	'ProcessFINISHED' : 'Prozess beendet',
 	'duplicatednotallowed' : 'Duplizierte Module sind nicht erlaubt',
-	'HAS_THIS_AS_ONLY_CHILD' : 'hat diese Platte als Einzelkind'
+	'HAS_THIS_AS_NTH_CHILD' : ' Hat dieses als ein weiteres Kind'
 };

--- a/include/js/de_de.lang.js
+++ b/include/js/de_de.lang.js
@@ -418,5 +418,6 @@ var alert_arr = {
 	'OF' : 'von',
 	'ERR_Massedit' : 'Fehler bei der Massenbearbeitung',
 	'ProcessFINISHED' : 'Prozess beendet',
-	'duplicatednotallowed' : 'Duplizierte Module sind nicht erlaubt'
+	'duplicatednotallowed' : 'Duplizierte Module sind nicht erlaubt',
+	'HAS_THIS_AS_ONLY_CHILD' : 'hat diese Platte als Einzelkind'
 };

--- a/include/js/de_de.lang.js
+++ b/include/js/de_de.lang.js
@@ -419,5 +419,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Fehler bei der Massenbearbeitung',
 	'ProcessFINISHED' : 'Prozess beendet',
 	'duplicatednotallowed' : 'Duplizierte Module sind nicht erlaubt',
-	'HAS_THIS_AS_NTH_CHILD' : ' Hat dieses als ein weiteres Kind'
+	'HAS_THIS_AS_NTH_CHILD' : 'Hat dieses als ein weiteres Kind'
 };

--- a/include/js/en_gb.lang.js
+++ b/include/js/en_gb.lang.js
@@ -384,5 +384,6 @@ var alert_arr = {
 	'OF' : 'of',
 	'ERR_Massedit' : 'Error on Mass Edit',
 	'ProcessFINISHED' : 'Process Finished',
-	'duplicatednotallowed' : 'Duplicated Modules Not Allowed'
+	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
+	'HAS_THIS_AS_ONLY_CHILD' : 'Has this record as only child'
 };

--- a/include/js/en_gb.lang.js
+++ b/include/js/en_gb.lang.js
@@ -385,5 +385,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Error on Mass Edit',
 	'ProcessFINISHED' : 'Process Finished',
 	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
-	'HAS_THIS_AS_ONLY_CHILD' : 'Has this record as only child'
+	'HAS_THIS_AS_NTH_CHILD' : 'Has this record as nth child'
 };

--- a/include/js/en_us.lang.js
+++ b/include/js/en_us.lang.js
@@ -421,5 +421,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Error on Mass Edit',
 	'ProcessFINISHED' : 'Process Finished',
 	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
-	'HAS_THIS_AS_ONLY_CHILD' : 'Has this record as only child'
+	'HAS_THIS_AS_NTH_CHILD' : 'Has this record as nth child'
 };

--- a/include/js/en_us.lang.js
+++ b/include/js/en_us.lang.js
@@ -420,5 +420,6 @@ var alert_arr = {
 	'OF' : 'of',
 	'ERR_Massedit' : 'Error on Mass Edit',
 	'ProcessFINISHED' : 'Process Finished',
-	'duplicatednotallowed' : 'Duplicated Modules Not Allowed'
+	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
+	'HAS_THIS_AS_ONLY_CHILD' : 'Has this record as only child'
 };

--- a/include/js/es_es.lang.js
+++ b/include/js/es_es.lang.js
@@ -419,5 +419,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Error en Edición Masiva',
 	'ProcessFINISHED' : 'Proceso Terminado',
 	'duplicatednotallowed' : 'No se permiten módulos duplicados',
-	'HAS_THIS_AS_NTH_CHILD' : ' Tiene este niño como una'
+	'HAS_THIS_AS_NTH_CHILD' : 'Tiene este niño como una'
 };

--- a/include/js/es_es.lang.js
+++ b/include/js/es_es.lang.js
@@ -419,5 +419,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Error en Edición Masiva',
 	'ProcessFINISHED' : 'Proceso Terminado',
 	'duplicatednotallowed' : 'No se permiten módulos duplicados',
-	'HAS_THIS_AS_ONLY_CHILD' : 'tiene este registro como hijo único'
+	'HAS_THIS_AS_NTH_CHILD' : ' Tiene este niño como una'
 };

--- a/include/js/es_es.lang.js
+++ b/include/js/es_es.lang.js
@@ -418,5 +418,6 @@ var alert_arr = {
 	'OF' : 'de',
 	'ERR_Massedit' : 'Error en Edición Masiva',
 	'ProcessFINISHED' : 'Proceso Terminado',
-	'duplicatednotallowed' : 'No se permiten módulos duplicados'
+	'duplicatednotallowed' : 'No se permiten módulos duplicados',
+	'HAS_THIS_AS_ONLY_CHILD' : 'tiene este registro como hijo único'
 };

--- a/include/js/es_mx.lang.js
+++ b/include/js/es_mx.lang.js
@@ -416,5 +416,6 @@ var alert_arr = {
 	'OF' : 'de',
 	'ERR_Massedit' : 'Error en Edición Masiva',
 	'ProcessFINISHED' : 'Proceso Terminado',
-	'duplicatednotallowed' : 'No se permiten módulos duplicados'
+	'duplicatednotallowed' : 'No se permiten módulos duplicados',
+	'HAS_THIS_AS_NTH_CHILD' : ' Tiene este niño como una'
 };

--- a/include/js/es_mx.lang.js
+++ b/include/js/es_mx.lang.js
@@ -417,5 +417,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Error en Edición Masiva',
 	'ProcessFINISHED' : 'Proceso Terminado',
 	'duplicatednotallowed' : 'No se permiten módulos duplicados',
-	'HAS_THIS_AS_NTH_CHILD' : ' Tiene este niño como una'
+	'HAS_THIS_AS_NTH_CHILD' : 'Tiene este niño como una'
 };

--- a/include/js/fr_fr.lang.js
+++ b/include/js/fr_fr.lang.js
@@ -406,5 +406,6 @@ var alert_arr = {
 	'OF' : 'of',
 	'ERR_Massedit' : 'Error on Mass Edit',
 	'ProcessFINISHED' : 'Process Finished',
-	'duplicatednotallowed' : 'Duplicated Modules Not Allowed'
+	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
+	'HAS_THIS_AS_ONLY_CHILD' : 'a cet enregistrement comme seul enfant'
 };

--- a/include/js/fr_fr.lang.js
+++ b/include/js/fr_fr.lang.js
@@ -407,5 +407,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Error on Mass Edit',
 	'ProcessFINISHED' : 'Process Finished',
 	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
-	'HAS_THIS_AS_NTH_CHILD' : ' A cet enfant comme un autre'
+	'HAS_THIS_AS_NTH_CHILD' : 'A cet enfant comme un autre'
 };

--- a/include/js/fr_fr.lang.js
+++ b/include/js/fr_fr.lang.js
@@ -407,5 +407,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Error on Mass Edit',
 	'ProcessFINISHED' : 'Process Finished',
 	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
-	'HAS_THIS_AS_ONLY_CHILD' : 'a cet enregistrement comme seul enfant'
+	'HAS_THIS_AS_NTH_CHILD' : ' A cet enfant comme un autre'
 };

--- a/include/js/hu_hu.lang.js
+++ b/include/js/hu_hu.lang.js
@@ -399,5 +399,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Error on Mass Edit',
 	'ProcessFINISHED' : 'Process Finished',
 	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
-	'HAS_THIS_AS_ONLY_CHILD' : 'már ezt a rekordot, mint csak a gyermek'
+	'HAS_THIS_AS_NTH_CHILD' : ' Ez még egy másik gyermek'
 };

--- a/include/js/hu_hu.lang.js
+++ b/include/js/hu_hu.lang.js
@@ -398,5 +398,6 @@ var alert_arr = {
 	'OF' : 'of',
 	'ERR_Massedit' : 'Error on Mass Edit',
 	'ProcessFINISHED' : 'Process Finished',
-	'duplicatednotallowed' : 'Duplicated Modules Not Allowed'
+	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
+	'HAS_THIS_AS_ONLY_CHILD' : 'már ezt a rekordot, mint csak a gyermek'
 };

--- a/include/js/hu_hu.lang.js
+++ b/include/js/hu_hu.lang.js
@@ -399,5 +399,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Error on Mass Edit',
 	'ProcessFINISHED' : 'Process Finished',
 	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
-	'HAS_THIS_AS_NTH_CHILD' : ' Ez még egy másik gyermek'
+	'HAS_THIS_AS_NTH_CHILD' : 'Ez még egy másik gyermek'
 };

--- a/include/js/it_it.lang.js
+++ b/include/js/it_it.lang.js
@@ -404,5 +404,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Errore di Mass Edit',
 	'ProcessFINISHED' : 'Processo Terminato',
 	'duplicatednotallowed' : 'Non sono permessi Moduli Duplicati',
-	'HAS_THIS_AS_ONLY_CHILD' : 'ha questo record come figlio unico'
+	'HAS_THIS_AS_NTH_CHILD' : 'ha questo record come figlio unico'
 };

--- a/include/js/it_it.lang.js
+++ b/include/js/it_it.lang.js
@@ -403,5 +403,6 @@ var alert_arr = {
 	'OF' : 'di',
 	'ERR_Massedit' : 'Errore di Mass Edit',
 	'ProcessFINISHED' : 'Processo Terminato',
-	'duplicatednotallowed' : 'Non sono permessi Moduli Duplicati'
+	'duplicatednotallowed' : 'Non sono permessi Moduli Duplicati',
+	'HAS_THIS_AS_ONLY_CHILD' : 'ha questo record come figlio unico'
 };

--- a/include/js/nl_nl.lang.js
+++ b/include/js/nl_nl.lang.js
@@ -420,5 +420,6 @@ var alert_arr = {
 	'OF' : 'van',
 	'ERR_Massedit' : 'Fout tijdens massa wijzig',
 	'ProcessFINISHED' : 'Proces beëindigd',
-	'duplicatednotallowed' : 'Duplicated Modules Not Allowed'
+	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
+	'HAS_THIS_AS_ONLY_CHILD' : 'Heeft dit record als enige kind'
 };

--- a/include/js/nl_nl.lang.js
+++ b/include/js/nl_nl.lang.js
@@ -421,5 +421,5 @@ var alert_arr = {
 	'ERR_Massedit' : 'Fout tijdens massa wijzig',
 	'ProcessFINISHED' : 'Proces beëindigd',
 	'duplicatednotallowed' : 'Duplicated Modules Not Allowed',
-	'HAS_THIS_AS_ONLY_CHILD' : 'Heeft dit record als enige kind'
+	'HAS_THIS_AS_NTH_CHILD' : 'Heeft dit record als Xste kind'
 };

--- a/modules/com_vtiger_workflow/VTJsonCondition.inc
+++ b/modules/com_vtiger_workflow/VTJsonCondition.inc
@@ -470,24 +470,36 @@ class VTJsonCondition {
 					return true;
 				}
 				return false;
-			case 'has this as only child':
+			case 'has this as nth child':
 				global $adb;
+				$value = (int)$value;
 
-				list($child_wsid, $child_id) = explode('x', $data['id']);
-				list($parent_wsid, $parent_id) = explode('x', $data[$cond['fieldname']]);
-				$child_setype = getSalesEntityType($child_id);
+				if ($value != 0) {
+					require_once 'vtlib/Vtiger/Module.php';
 
-				require_once 'modules/' . $child_setype . '/' . $child_setype . '.php';
-				$child_focus = new $child_setype();
+					list($child_wsid, $child_id) = explode('x', $data['id']);
+					list($parent_wsid, $parent_id) = explode('x', $data[$cond['fieldname']]);
+					$child_setype = getSalesEntityType($child_id);
+					$children = array();
 
-				$r = $adb->query("SELECT {$child_focus->table_index} FROM {$child_focus->table_name}
-					              INNER JOIN vtiger_crmentity ON
-					              {$child_focus->table_name}.{$child_focus->table_index} = vtiger_crmentity.crmid 
-					              WHERE {$cond['fieldname']} = {$parent_id}
-					              AND vtiger_crmentity.deleted = 0");
+					$mod = Vtiger_Module::getInstance($child_setype);
+					$field = Vtiger_Field::getInstance($cond['fieldname'], $mod);
 
-				if ((int)$adb->num_rows($r) === 1 && $adb->fetch_array($r)[$child_focus->table_index] === $child_id) {
-					return true;
+					$r = $adb->query("SELECT {$field->table}.{$mod->basetableid}
+					                  FROM {$field->table}
+						              INNER JOIN vtiger_crmentity ON
+						              {$field->table}.{$mod->basetableid} = vtiger_crmentity.crmid
+						              WHERE {$field->table}.{$cond['fieldname']} = {$parent_id}
+						              AND vtiger_crmentity.deleted = 0
+						              ORDER BY vtiger_crmentity.createdtime ASC");
+					while ($child = $adb->fetch_array($r)) {
+						$children[] = $child[$mod->basetableid];
+					}
+					if ($value = $adb->num_rows($r) && $children[$value - 1] == $child_id) {
+						return true;
+					} else {
+						return false;
+					}
 				} else {
 					return false;
 				}

--- a/modules/com_vtiger_workflow/VTJsonCondition.inc
+++ b/modules/com_vtiger_workflow/VTJsonCondition.inc
@@ -470,6 +470,28 @@ class VTJsonCondition {
 					return true;
 				}
 				return false;
+			case 'has this as only child':
+				global $adb;
+
+				list($child_wsid, $child_id) = explode('x', $data['id']);
+				list($parent_wsid, $parent_id) = explode('x', $data[$cond['fieldname']]);
+				$child_setype = getSalesEntityType($child_id);
+
+				require_once 'modules/' . $child_setype . '/' . $child_setype . '.php';
+				$child_focus = new $child_setype();
+
+				$r = $adb->query("SELECT {$child_focus->table_index} FROM {$child_focus->table_name}
+					              INNER JOIN vtiger_crmentity ON
+					              {$child_focus->table_name}.{$child_focus->table_index} = vtiger_crmentity.crmid 
+					              WHERE {$cond['fieldname']} = {$parent_id}
+					              AND vtiger_crmentity.deleted = 0");
+
+				if ((int)$adb->num_rows($r) === 1 && $adb->fetch_array($r)[$child_focus->table_index] === $child_id) {
+					return true;
+				} else {
+					return false;
+				}
+				break;
 			default:
 				//Unexpected condition
 				throw new Exception('Found an unexpected condition: ' . $condition);

--- a/modules/com_vtiger_workflow/resources/editworkflowscript.js
+++ b/modules/com_vtiger_workflow/resources/editworkflowscript.js
@@ -209,7 +209,7 @@ function editworkflowscript($, conditions) {
 		var op = {
 			string:['is', 'contains', 'does not contain', 'starts with', 'ends with', 'has changed', 'is empty', 'is not empty', 'exists', 'does not start with', 'does not end with', 'was'],
 			number:['equal to', 'less than', 'greater than', 'does not equal', 'less than or equal to', 'greater than or equal to', 'has changed', 'exists', 'was'],
-			value:['is', 'is not', 'has changed', 'has changed to', 'is empty', 'is not empty', 'exists', 'was', 'has this as only child'],
+			value:['is', 'is not', 'has changed', 'has changed to', 'is empty', 'is not empty', 'exists', 'was', 'has this as nth child'],
 			multipicklist:['is', 'is not', 'was'],
 			date:['is', 'is not', 'has changed', 'has changed to', 'between', 'before', 'after', 'is today', 'less than days ago', 'more than days ago', 'in less than', 'in more than', 'days ago', 'days later', 'exists', 'was'],
 			datetime:['is', 'is not', 'has changed', 'has changed to', 'less than hours before', 'less than hours later', 'more than hours before', 'more than hours later', 'equal to', 'less than', 'greater than', 'does not equal', 'less than or equal to', 'greater than or equal to', 'exists', 'was']
@@ -244,7 +244,7 @@ function editworkflowscript($, conditions) {
 			value:[alert_arr.LBL_IS, alert_arr.LBL_IS_NOT, alert_arr.LBL_HAS_CHANGED, alert_arr.LBL_HAS_CHANGED_TO, alert_arr.LBL_IS_EMPTY, alert_arr.LBL_IS_NOT_EMPTY,
 				alert_arr.LBL_EXISTS, alert_arr.LBL_WAS],
 			reference:[alert_arr.LBL_IS, alert_arr.LBL_IS_NOT, alert_arr.LBL_HAS_CHANGED, alert_arr.LBL_HAS_CHANGED_TO, alert_arr.LBL_IS_EMPTY, alert_arr.LBL_IS_NOT_EMPTY,
-				alert_arr.LBL_EXISTS, alert_arr.LBL_WAS, alert_arr.HAS_THIS_AS_ONLY_CHILD],
+				alert_arr.LBL_EXISTS, alert_arr.LBL_WAS, alert_arr.HAS_THIS_AS_NTH_CHILD],
 			date:[alert_arr.LBL_IS, alert_arr.LBL_IS_NOT, alert_arr.LBL_HAS_CHANGED, alert_arr.LBL_HAS_CHANGED_TO,
 				alert_arr.LBL_BETWEEN, alert_arr.LBL_BEFORE, alert_arr.LBL_AFTER, alert_arr.LBL_IS_TODAY, alert_arr.LBL_LESS_THAN_DAYS_AGO,
 				alert_arr.LBL_MORE_THAN_DAYS_AGO, alert_arr.LBL_IN_LESS_THAN, alert_arr.LBL_IN_MORE_THAN, alert_arr.LBL_DAYS_AGO, alert_arr.LBL_DAYS_LATER,
@@ -623,7 +623,7 @@ function editworkflowscript($, conditions) {
 						var condition = $('#save_condition_'+condid+'_operation');
 						condition.bind('change', function () {
 							var value = $(this).val();
-							if (value == 'is empty' || value == 'is not empty' || value == 'has this as only child') {
+							if (value == 'is empty' || value == 'is not empty') {
 								$('#save_condition_'+condid+'_value').hide();
 							} else {
 								$('#save_condition_'+condid+'_value').show();

--- a/modules/com_vtiger_workflow/resources/editworkflowscript.js
+++ b/modules/com_vtiger_workflow/resources/editworkflowscript.js
@@ -209,7 +209,7 @@ function editworkflowscript($, conditions) {
 		var op = {
 			string:['is', 'contains', 'does not contain', 'starts with', 'ends with', 'has changed', 'is empty', 'is not empty', 'exists', 'does not start with', 'does not end with', 'was'],
 			number:['equal to', 'less than', 'greater than', 'does not equal', 'less than or equal to', 'greater than or equal to', 'has changed', 'exists', 'was'],
-			value:['is', 'is not', 'has changed', 'has changed to', 'is empty', 'is not empty', 'exists', 'was'],
+			value:['is', 'is not', 'has changed', 'has changed to', 'is empty', 'is not empty', 'exists', 'was', 'has this as only child'],
 			multipicklist:['is', 'is not', 'was'],
 			date:['is', 'is not', 'has changed', 'has changed to', 'between', 'before', 'after', 'is today', 'less than days ago', 'more than days ago', 'in less than', 'in more than', 'days ago', 'days later', 'exists', 'was'],
 			datetime:['is', 'is not', 'has changed', 'has changed to', 'less than hours before', 'less than hours later', 'more than hours before', 'more than hours later', 'equal to', 'less than', 'greater than', 'does not equal', 'less than or equal to', 'greater than or equal to', 'exists', 'was']
@@ -244,7 +244,7 @@ function editworkflowscript($, conditions) {
 			value:[alert_arr.LBL_IS, alert_arr.LBL_IS_NOT, alert_arr.LBL_HAS_CHANGED, alert_arr.LBL_HAS_CHANGED_TO, alert_arr.LBL_IS_EMPTY, alert_arr.LBL_IS_NOT_EMPTY,
 				alert_arr.LBL_EXISTS, alert_arr.LBL_WAS],
 			reference:[alert_arr.LBL_IS, alert_arr.LBL_IS_NOT, alert_arr.LBL_HAS_CHANGED, alert_arr.LBL_HAS_CHANGED_TO, alert_arr.LBL_IS_EMPTY, alert_arr.LBL_IS_NOT_EMPTY,
-				alert_arr.LBL_EXISTS, alert_arr.LBL_WAS],
+				alert_arr.LBL_EXISTS, alert_arr.LBL_WAS, alert_arr.HAS_THIS_AS_ONLY_CHILD],
 			date:[alert_arr.LBL_IS, alert_arr.LBL_IS_NOT, alert_arr.LBL_HAS_CHANGED, alert_arr.LBL_HAS_CHANGED_TO,
 				alert_arr.LBL_BETWEEN, alert_arr.LBL_BEFORE, alert_arr.LBL_AFTER, alert_arr.LBL_IS_TODAY, alert_arr.LBL_LESS_THAN_DAYS_AGO,
 				alert_arr.LBL_MORE_THAN_DAYS_AGO, alert_arr.LBL_IN_LESS_THAN, alert_arr.LBL_IN_MORE_THAN, alert_arr.LBL_DAYS_AGO, alert_arr.LBL_DAYS_LATER,
@@ -623,7 +623,7 @@ function editworkflowscript($, conditions) {
 						var condition = $('#save_condition_'+condid+'_operation');
 						condition.bind('change', function () {
 							var value = $(this).val();
-							if (value == 'is empty' || value == 'is not empty') {
+							if (value == 'is empty' || value == 'is not empty' || value == 'has this as only child') {
 								$('#save_condition_'+condid+'_value').hide();
 							} else {
 								$('#save_condition_'+condid+'_value').show();


### PR DESCRIPTION
OK, this works rudimentary. What this allows you to do is take a reference field in the workflow conditions and select 'has this as only child'. So if you are working on for instance assets and you want to know if this asset is the only one that the related account has, this will let you do stuff decided on if that is true.

When you select it, the input box disappears (by design) since it has no function. We could re-add it and expand the function to some sort of siblingcount? Also, I can't find how to hide the input box when entering the workflow or task, only when the picklist changes.