### PR TITLE
fix(Users) Allow read global variable before login

### DIFF
--- a/build/changeSets/DefineGlobalVariables.php
+++ b/build/changeSets/DefineGlobalVariables.php
@@ -140,7 +140,8 @@ class DefineGlobalVariables extends cbupdaterWorker {
 				'User_AuthenticationType',
 				'User_2FAAuthentication',
 				'User_2FAAuthentication_SendMethod',
-
+				'User_MandatoryAuthenticationSQL',	
+				
 				'Accounts_BlockDuplicateName',
 				'Campaign_CreatePotentialOnAccountRelation',
 				'Campaign_CreatePotentialOnContactRelation',

--- a/modules/Users/Users.php
+++ b/modules/Users/Users.php
@@ -280,17 +280,29 @@ class Users extends CRMEntity {
 	 * @return true if the user is authenticated, false otherwise
 	 */
 	public function doLogin($user_password) {
-		$authType = GlobalVariable::getVariable('User_AuthenticationType', 'SQL');
-		if ($this->is_admin) {
-			$authType = 'SQL'; // admin users always login locally
-		}
 		$usr_name = $this->column_fields["user_name"];
+		$result = $this->db->pquery('select id from vtiger_users where user_name=?', array($usr_name));
+		if ($result && $this->db->num_rows($result)==1) {
+				$row = $this->db->fetchByAssoc($result);
+				$userid = $row['id'];
+		} else {
+				return false;
+		}
+		$authType = GlobalVariable::getVariable('User_AuthenticationType', 'SQL', 'Users', $userid);		
+		
+		$sql_auth_users = GlobalVariable::getVariable('User_MandatoryAuthenticationSQL', 'admin', 'Users', $userid);
+		$sql_auth_users = explode(',', $sql_auth_users);
+
+		if (in_array($usr_name, $sql_auth_users)) {
+		   $this->log->debug("$usr_name exists in sql_auth_users, so using SQL Authentication");
+		  $authType = 'SQL';
+		}
 
 		switch (strtoupper($authType)) {
 			case 'LDAP':
 				$this->log->debug("Using LDAP authentication");
 				require_once 'modules/Users/authTypes/LDAP.php';
-				$result = ldapAuthenticate($this->column_fields["user_name"], $user_password);
+				$result = ldapAuthenticate($usr_name, $user_password);
 				if ($result == null) {
 					return false;
 				} else {
@@ -302,7 +314,7 @@ class Users extends CRMEntity {
 				$this->log->debug("Using Active Directory authentication");
 				require_once 'modules/Users/authTypes/adLDAP.php';
 				$adldap = new adLDAP();
-				if ($adldap->authenticate($this->column_fields["user_name"], $user_password)) {
+				if ($adldap->authenticate($usr_name, $user_password)) {
 					return true;
 				} else {
 					return false;


### PR DESCRIPTION
so that AD/LDAP Authentication will work

As per discussion at https://discussions.corebos.org/showthread.php?tid=1558

Is there anything else needed here?