### PR TITLE
feat(ProductAutocomplete) Prepare for modern inventory block

### DIFF
--- a/include/js/Inventory.js
+++ b/include/js/Inventory.js
@@ -1420,10 +1420,10 @@ function InventorySelectAll(mod, image_pth) {
 }
 
 /****
-* ProductAutocomplete
-* @author: MajorLabel <info@majorlabel.nl>
-* @license VPL
-*/
+	* ProductAutocomplete
+	* @author: MajorLabel <info@majorlabel.nl>
+	* @license VPL
+	*/
 (function productautocompleteModule(factory) {
 
 	if (typeof define === 'function' && define.amd) {
@@ -1826,17 +1826,17 @@ function InventorySelectAll(mod, image_pth) {
 		},
 
 		/*
-			* Class utilities
-			*/
+		 * Class utilities
+		 */
 		utils : {
 			/*
-				* Util: 'findUp'
-				* Returns the first element up the DOM that matches the search
-				*
-				* @param: element: 	the node to start from
-				* @param: searchterm: 	Can be a class (prefix with '.'), ID (prefix with '#')
-				*						or an attribute (default when no prefix)
-				*/
+			 * Util: 'findUp'
+			 * Returns the first element up the DOM that matches the search
+			 *
+			 * @param: element: 	the node to start from
+			 * @param: searchterm: 	Can be a class (prefix with '.'), ID (prefix with '#')
+			 *						or an attribute (default when no prefix)
+			 */
 			findUp : function (element, searchterm) {
 				element = element.children[0] != undefined ? element.children[0] : element; // Include the current element
 				while (element = element.parentElement) {
@@ -1851,25 +1851,25 @@ function InventorySelectAll(mod, image_pth) {
 				}
 			},
 			/*
-				* Util: 'getFirstClass'
-				* Returns the first element from the root that matches
-				* the classname
-				*
-				* @param: root: 		the node to start from
-				* @param: className: 	The classname to search for
-				*/
+			 * Util: 'getFirstClass'
+			 * Returns the first element from the root that matches
+			 * the classname
+			 *
+			 * @param: root: 		the node to start from
+			 * @param: className: 	The classname to search for
+			 */
 			getFirstClass: function (root, className) {
 				return root.getElementsByClassName(className)[0] != undefined ? root.getElementsByClassName(className)[0] : {};
 			},
 			/*
-				* Util: 'on'
-				* Adds an event listener
-				*
-				* @param: el: 			The node to attach the listener to
-				* @param: type: 		The type of event
-				* @param: func: 		The function to perform
-				* @param: context: 	The context to bind the listener to
-				*/
+			 * Util: 'on'
+			 * Adds an event listener
+			 *
+			 * @param: el: 			The node to attach the listener to
+			 * @param: type: 		The type of event
+			 * @param: func: 		The function to perform
+			 * @param: context: 	The context to bind the listener to
+			 */
 			on: function (el, type, func, context) {
 				try {
 					el.addEventListener(type, func.bind(context));
@@ -1878,43 +1878,43 @@ function InventorySelectAll(mod, image_pth) {
 				}
 			},
 			/*
-				* Util: 'off'
-				* Removes an event listener
-				*
-				* @param: el: 			The node to remove the listener from
-				* @param: type: 		The type of event
-				* @param: func: 		The function to remove
-				*/
+			 * Util: 'off'
+			 * Removes an event listener
+			 *
+			 * @param: el: 			The node to remove the listener from
+			 * @param: type: 		The type of event
+			 * @param: func: 		The function to remove
+			 */
 			off: function (el, type, func) {
 				el.removeEventListener(type, func);
 			},
 			/*
-				* Util: 'insertAfter'
-				* Inserts a new node after the given
-				*
-				* @param: referenceNode: 	The node to insert after
-				* @param: newNode: 		The node to insert
-				*/
+			 * Util: 'insertAfter'
+			 * Inserts a new node after the given
+			 *
+			 * @param: referenceNode: 	The node to insert after
+			 * @param: newNode: 		The node to insert
+			 */
 			insertAfter: function (referenceNode, newNode) {
 				referenceNode.parentNode.insertBefore(newNode, referenceNode.nextSibling);
 			},
 			/*
-				* Util: 'deductPerc'
-				* deducts a percentage from a number
-				*
-				* @param: base: 		The base '100%' number
-				* @param: percentage: 	The percentage to deduct
-				*/
+			 * Util: 'deductPerc'
+			 * deducts a percentage from a number
+			 *
+			 * @param: base: 		The base '100%' number
+			 * @param: percentage: 	The percentage to deduct
+			 */
 			deductPerc: function (base, percentage) {
 				return (base * (1 - (percentage / 100)));
 			},
 			/*
-				* Util: 'getPerc'
-				* Returns a percentage of a base no.
-				*
-				* @param: base: 		The base '100%' number
-				* @param: percentage: 	The percentage to return
-				*/
+			 * Util: 'getPerc'
+			 * Returns a percentage of a base no.
+			 *
+			 * @param: base: 		The base '100%' number
+			 * @param: percentage: 	The percentage to return
+			 */
 			getPerc: function (base, percentage) {
 				return base * (percentage / 100);
 			}
@@ -1922,8 +1922,8 @@ function InventorySelectAll(mod, image_pth) {
 	};
 
 	/**
-		 * Section with factory tools
-		 */
+	  * Section with factory tools
+	  */
 	function _createEl(elType, className, inner) {
 		var el = document.createElement(elType);
 		if (className.indexOf(' ') == -1 && className != undefined && className != '') {
@@ -1947,8 +1947,8 @@ function InventorySelectAll(mod, image_pth) {
 	}
 
 	/*
-		* Globals
-		*/
+	 * Globals
+	 */
 	window.keycodeMap = {
 		38: 'up',
 		40: 'down',
@@ -1960,8 +1960,8 @@ function InventorySelectAll(mod, image_pth) {
 	};
 
 	/*
-		* Export
-		*/
+	 * Export
+	 */
 	return ProductAutocomplete;
 });
 


### PR DESCRIPTION
OK, so here's a new one off an up-to-date master and without indentation changes. As I explained in a PR that I closed before it had a change to be reviewed, the multicurrency is not gone, you just placed it in the wrong place. The `fillLine` method of the module uses the '[else](https://github.com/tsolucio/corebos/pull/836/files#diff-dc52855ef3d2e5662b79a6512e087a12R1804)' to do a custom callback in the current inventorymodules. In this case hand the information over to [`handleProductAutocompleteSelect`](https://github.com/tsolucio/corebos/blob/master/include/js/Inventory.js#L1938), which is where the multicurrency happens.

The main block of `fillLine` uses the [modules](https://github.com/Luke1982/WorkAssignment/blob/master/modules/WorkAssignment/WorkAssignment.js) I wrote to handle modern inventorylines, which were originally written to work together. I only took out the autocomplete and suited it for the current way of doing inventory so we wouldn't have to wait so long on autocomplete in the product search fields.