### PR TITLE
Fix multi currency

### DIFF
--- a/include/Webservices/CustomerPortalWS.php
+++ b/include/Webservices/CustomerPortalWS.php
@@ -1135,7 +1135,7 @@ function getProductServiceAutocomplete($term, $returnfields = array(), $limit = 
 		while ($mcinfo = $adb->fetch_array($multic)) {
 			$mc[$mcinfo['currencyid']] = array(
 				'converted_price' => number_format((float)$mcinfo['converted_price'], $cur_user_decimals, '.', ''),
-				'actual_price' => number_format((float)$unitprice, $cur_user_decimals, '.', ''),
+				'actual_price' => number_format((float)$mcinfo['actual_price'], $cur_user_decimals, '.', ''),
 			);
 		}
 		$ret_prodser['pricing']['multicurrency'] = $mc;

--- a/include/js/Inventory.js
+++ b/include/js/Inventory.js
@@ -1976,7 +1976,10 @@ function handleProductAutocompleteSelect(obj) {
 	document.getElementById('comment'+no).innerHTML = obj.result.meta.comments;
 	var currency = document.getElementById('inventory_currency').value;
 	if (obj.result.pricing.multicurrency[currency] != undefined && gVTModule != 'PurchaseOrder' && gVTModule != 'Receiptcards') {
-		document.getElementById('listPrice'+no).value = obj.result.pricing.multicurrency[currency].converted_price;
+		if (Object.keys(obj.result.pricing.multicurrency).length == 1 && obj.result.pricing.multicurrency[currency].actual_price != obj.result.pricing.unit_price) {
+			ldsPrompt.show(alert_arr['Warning'], alert_arr.ACT_UNIT_PRICE_MISMATCH);
+		}
+		document.getElementById('listPrice'+no).value = obj.result.pricing.multicurrency[currency].actual_price;
 	} else {
 		var list_price = obj.result.pricing.unit_price;
 		if (gVTModule == 'PurchaseOrder' || gVTModule == 'Receiptcards' ) {

--- a/include/js/en_gb.lang.js
+++ b/include/js/en_gb.lang.js
@@ -393,5 +393,6 @@ var alert_arr = {
 	'Okay': 'Okay',
 	'Failed': 'Failed',
 	'Warning': 'Warning',
-	'Copied': 'Copied'
+	'Copied': 'Copied',
+	'ACT_UNIT_PRICE_MISMATCH': 'The actual price for this currency should be equal to the unit price, but this is not the case for this product or service'
 };

--- a/include/js/en_us.lang.js
+++ b/include/js/en_us.lang.js
@@ -429,5 +429,6 @@ var alert_arr = {
 	'Okay': 'Okay',
 	'Failed': 'Failed',
 	'Warning': 'Warning',
-	'Copied': 'Copied'
+	'Copied': 'Copied',
+	'ACT_UNIT_PRICE_MISMATCH': 'The actual price for this currency should be equal to the unit price, but this is not the case for this product or service'
 };

--- a/include/js/fr_fr.lang.js
+++ b/include/js/fr_fr.lang.js
@@ -415,5 +415,6 @@ var alert_arr = {
 	'Okay': 'Okay',
 	'Failed': 'Failed',
 	'Warning': 'Warning',
-	'Copied': 'Copied'
+	'Copied': 'Copied',
+	'ACT_UNIT_PRICE_MISMATCH': 'Le prix réel de cette devise doit être égal au prix unitaire, mais ce n\'est pas le cas pour ce produit ou service'
 };

--- a/include/js/it_it.lang.js
+++ b/include/js/it_it.lang.js
@@ -412,5 +412,6 @@ var alert_arr = {
 	'Okay': 'Okay',
 	'Failed': 'Failed',
 	'Warning': 'Warning',
-	'Copied': 'Copied'
+	'Copied': 'Copied',
+	'ACT_UNIT_PRICE_MISMATCH': 'Il prezzo effettivo per questa valuta dovrebbe essere uguale al prezzo unitario, ma questo non è il caso di questo prodotto o servizio'
 };

--- a/include/js/nl_nl.lang.js
+++ b/include/js/nl_nl.lang.js
@@ -429,5 +429,6 @@ var alert_arr = {
 	'Okay': 'Oké',
 	'Failed': 'Failed',
 	'Warning': 'Warning',
-	'Copied': 'Copied'
+	'Copied': 'Copied',
+	'ACT_UNIT_PRICE_MISMATCH': 'De actuele prijs van de valuta zou overeen moeten komen met de verkoopprijs, maar dit is niet het geval voor dit product of deze dienst'
 };

--- a/include/js/pt_br.lang.js
+++ b/include/js/pt_br.lang.js
@@ -428,5 +428,6 @@ var alert_arr = {
 	'Okay': 'Ok',
 	'Failed': 'Falhou',
 	'Warning': 'Alerta',
-	'Copied': 'Copiado'
+	'Copied': 'Copiado',
+	'ACT_UNIT_PRICE_MISMATCH': 'O preço real para esta moeda deve ser igual ao preço unitário, mas este não é o caso para este produto ou serviço'
 };


### PR DESCRIPTION
The collection of MC-prices from the DB is altered so that the actual price is used in stead of the unitprice, and the converted price is changed to the actual price when filling in the prices in the frontend. On top of that, during the filling of the prices there is a check that warns the user when:
- There is only one entry in the multicurrency object (indicating that basically there is no multicurrency)
- The actual price of that entry does not match the unit price (which should always be the same when there's only one currency active)

This warning is non-destructive: it'll just fill in the price from the MC object but will warn the user that something is up that needs checking. I left out the Spanish translation since you'd be better at that than Google Translate
