### PR TITLE
Solve page-shaking bug

### DIFF
--- a/include/js/general.js
+++ b/include/js/general.js
@@ -6496,7 +6496,8 @@ const pageHeader = {
 	},
 	'OnDownScroll' : () => {
 		if (pageHeader.node() !== null) {
-			if (window.scrollY > (pageHeader.stickPoint + 2) && !pageHeader.isSticky) {
+			pageHeader.collapse();
+			if (window.scrollY > (pageHeader.stickPoint + 2)) {
 				pageHeader.isSticky = true;
 				pageHeader.node().classList.add('page-header_sticky');
 				pageHeader.node().classList.add('slds-is-fixed');
@@ -6504,8 +6505,8 @@ const pageHeader = {
 				pageHeader.node().style.transform = 'translateY(' + pageHeader.getPremenuHeight() + 'px)';
 				pageHeader.collapse();
 			} else if (pageHeader.isSticky && !pageHeader.isCollapsed) {
-				pageHeader.collapse();
-			}
+			  pageHeader.collapse();
+		    }
 		}
 	},
 	'OnUpScroll' : () => {
@@ -6513,11 +6514,11 @@ const pageHeader = {
 			pageHeader.expand();
 			if (window.scrollY < (pageHeader.stickPoint - 2) && pageHeader.isSticky) {
 				pageHeader.isSticky = false;
-				window.setTimeout(function () {
+				// window.setTimeout(function () {
 					pageHeader.node().classList.remove('page-header_sticky');
 					pageHeader.node().classList.remove('slds-is-fixed');
 					pageHeader.placeholder().style.height = '0px';
-				}, 80);
+				// }, 80);
 				pageHeader.node().style.transform = 'translateY(0px)';
 			}
 		}
@@ -6554,9 +6555,10 @@ const pageHeader = {
 	}
 };
 
+var isWaiting = false;
 function headerOnDownScroll() {
 	var h = document.getElementById('global-header');
-	if (h !== null) {
+	if (h !== null && !isWaiting) {
 		h.classList.add('header-scrolling');
 		h.dispatchEvent(headerCollapse);
 		if ($(document).scrollLeft() >= 0 && $(document).scrollTop() == 0) {
@@ -6567,12 +6569,15 @@ function headerOnDownScroll() {
 window.cbOnDownScrollers.push(headerOnDownScroll, pageHeader.OnDownScroll);
 
 function headerOnUpScroll() {
-	var h = document.getElementById('global-header'),
-		csy = window.scrollY;
+	var h = document.getElementById('global-header');
+		// var csy = window.scrollY;
 
 	if (h !== null) {
+		isWaiting = true;
+		setTimeout(() => {isWaiting = false;}, 80);
 		h.classList.remove('header-scrolling');
 		h.dispatchEvent(headerExpand);
+		h.style.transition = 'none';
 	}
 }
 


### PR DESCRIPTION
These changes will avoid the occasional but troublesome conflict between the “#page-header” and the “#global-header” that produces a violent page shaking.