### PR TITLE
refactor(App) replaced deprecated utf8_encode into mb_convert_encoding

### DIFF
--- a/include/js/general.js
+++ b/include/js/general.js
@@ -7290,10 +7290,10 @@ $(function () {
 		// Variables privadas
 		var links = this.el.find('.link');
 		// Evento
-		links.on('click', { el: this.el, multiple: this.multiple }, this.dropdown);
+		links.on('click', { el: this.el, multiple: this.multiple }, verticalMenuDropdownHandler);
 	};
-
-	cbAccordion.prototype.dropdown = function (e) {
+	
+	function verticalMenuDropdownHandler (e) {
 		var $el = e.data.el,
 			$this = $(this),
 			$next = $this.next();

--- a/include/js/general.js
+++ b/include/js/general.js
@@ -7292,7 +7292,6 @@ $(function () {
 		// Evento
 		links.on('click', { el: this.el, multiple: this.multiple }, verticalMenuDropdownHandler);
 	};
-	
 	function verticalMenuDropdownHandler (e) {
 		var $el = e.data.el,
 			$this = $(this),

--- a/include/js/general.js
+++ b/include/js/general.js
@@ -7292,6 +7292,7 @@ $(function () {
 		// Evento
 		links.on('click', { el: this.el, multiple: this.multiple }, verticalMenuDropdownHandler);
 	};
+	
 	function verticalMenuDropdownHandler (e) {
 		var $el = e.data.el,
 			$this = $(this),

--- a/include/js/general.js
+++ b/include/js/general.js
@@ -7290,10 +7290,10 @@ $(function () {
 		// Variables privadas
 		var links = this.el.find('.link');
 		// Evento
-		links.on('click', { el: this.el, multiple: this.multiple }, verticalMenuDropdownHandler);
+		links.on('click', { el: this.el, multiple: this.multiple }, this.dropdown);
 	};
-	
-	function verticalMenuDropdownHandler (e) {
+
+	cbAccordion.prototype.dropdown = function (e) {
 		var $el = e.data.el,
 			$this = $(this),
 			$next = $this.next();

--- a/include/utils/utils.php
+++ b/include/utils/utils.php
@@ -1902,7 +1902,7 @@ function utf8RawUrlDecode($source) {
 				$unicodeHexVal = substr($source, $pos, 4);
 				$unicode = hexdec($unicodeHexVal);
 				$entity = '&#'. $unicode . ';';
-				$decodedStr .= utf8_encode($entity);
+				$decodedStr .= mb_convert_encoding($entity, "UTF-8", "ISO-8859-1");
 				$pos += 4;
 			} else {
 				// we have an escaped ascii character
@@ -2567,7 +2567,7 @@ function get_on_clause($field_list, $uitype_arr, $module) {
 function elimina_acentos($cadena) {
 	$tofind = utf8_decode('ÀÁÂÃÄÅàáâãäåÒÓÔÕÖØòóôõöøÈÉÊẼËèéêẽëÌÍĨÎÏìíîĩïÙÚÛŨÜúùûũüÿçÇºªñÑ');
 	$replac = 'AAAAAAaaaaaaOOOOOOooooooEEEEEeeeeeIIIIIiiiiiUUUUUuuuuuycCoanN';
-	return utf8_encode(strtr(utf8_decode($cadena), $tofind, $replac));
+	return mb_convert_encoding(strtr(utf8_decode($cadena), $tofind, $replac), "UTF-8", "ISO-8859-1");
 }
 
 /** call back function to change the array values in to lower case */

--- a/modules/evvtgendoc/compile.php
+++ b/modules/evvtgendoc/compile.php
@@ -1547,7 +1547,7 @@ if (!function_exists('elimina_puntuacion')) {
 		);
 		// elimina espacios
 		$cadena = str_replace(' ', '_', $cadena);
-		return utf8_encode(strtr(utf8_decode($cadena), $replac));
+		return mb_convert_encoding(strtr(utf8_decode($cadena), $replac), "UTF-8", "ISO-8859-1");
 	}
 }
 

--- a/webdav/CRMFile.php
+++ b/webdav/CRMFile.php
@@ -38,12 +38,12 @@ class CRMFile extends Sabre\DAV\File {
 		$fileid = $adb->query_result($result, 0, 'attachmentsid');
 		$pathQuery = $adb->pquery('select path from vtiger_attachments where attachmentsid=?', array($fileid));
 		$filepath = '../'.$adb->query_result($pathQuery, 0, 'path');
-		$saved_filename = $fileid.'_'.utf8_encode(html_entity_decode(html_entity_decode($this->data['filename'])));
+		$saved_filename = $fileid.'_'.mb_convert_encoding(html_entity_decode(html_entity_decode($this->data['filename'])), "UTF-8", "ISO-8859-1");
 		$this->filepath = realpath(dirname(__FILE__).'/'.$filepath.$saved_filename);
 	}
 
 	public function getName() {
-		return utf8_encode(html_entity_decode(html_entity_decode($this->data['filename'], ENT_COMPAT, 'UTF-8')));
+		return mb_convert_encoding(html_entity_decode(html_entity_decode($this->data['filename'], ENT_COMPAT, 'UTF-8')), "UTF-8", "ISO-8859-1");
 	}
 
 	public function setName($name) {
@@ -55,8 +55,8 @@ class CRMFile extends Sabre\DAV\File {
 		$adb->pquery('UPDATE vtiger_attachments SET name=? WHERE attachmentsid=?', array($name, $fileid));
 		$pathQuery = $adb->pquery('select path from vtiger_attachments where attachmentsid=?', array($fileid));
 		$filepath = '../'.$adb->query_result($pathQuery, 0, 'path');
-		$saved_filename = $fileid.'_'.utf8_encode(html_entity_decode(html_entity_decode($this->data['filename'])));
-		$new_saved_filename = $fileid.'_'.utf8_encode(html_entity_decode(html_entity_decode($name)));
+		$saved_filename = $fileid.'_'.mb_convert_encoding(html_entity_decode(html_entity_decode($this->data['filename'])), "UTF-8", "ISO-8859-1");
+		$new_saved_filename = $fileid.'_'.mb_convert_encoding(html_entity_decode(html_entity_decode($name)), "UTF-8", "ISO-8859-1");
 		$path = realpath(dirname(__FILE__).'/'.$filepath.$saved_filename);
 		$new_path = (dirname(__FILE__).'/'.$filepath.$new_saved_filename);
 		rename($path, $new_path);

--- a/webdav/DirectoryRecord.php
+++ b/webdav/DirectoryRecord.php
@@ -96,6 +96,6 @@ class DirectoryRecord extends Sabre\DAV\Collection {
 	}
 
 	public function getName() {
-		return utf8_encode(html_entity_decode($this->foldername));
+		return mb_convert_encoding(html_entity_decode($this->foldername), "UTF-8", "ISO-8859-1");
 	}
 }


### PR DESCRIPTION
## replaced deprecated utf8_encode into mb_convert_encoding

fun fact: we converted ISO-8859-1 into UTF-8 because These characters shown bellow (from 128 to 255) are stored using 1 byte for each character in ISO-8859-1. but in UTF-8 they are stored in multi byte space for each character.
That's why we need to convert it otherwise a UTF-8 encoder will not be able to read it.
![ksnip_20221020-220336](https://user-images.githubusercontent.com/59079190/197046767-45dfa47d-07a9-4c83-a436-ff3239bbfd60.png)
