### PR TITLE
feat(Popup) filter records in popup between 2 modules

### DIFF
--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -1646,14 +1646,14 @@ class CRMEntity {
 			if (!empty($conditions[$fieldname]) && json_decode($conditions[$fieldname]) == null) {
 				return $conditions[$fieldname];
 			}
-			if (!empty($conditions[$fieldname])) {
+			if (!empty($conditions[$fieldname]) || !empty($conditions[$module.'::'.$relatedModule])) {
 				$fields = $cbMapLC->getSearchFieldsName();
 				$wherepos = stripos($query, ' where ');
 				$query_body = substr($query, 0, $wherepos);
 				$workflowScheduler = new WorkFlowScheduler($adb);
 				$workflow = new Workflow();
 				$wfvals['module_name'] = $relatedModule;
-				$wfvals['test'] = $conditions[$fieldname];
+				$wfvals['test'] = isset($conditions[$fieldname]) ? $conditions[$fieldname] : $conditions[$module.'::'.$relatedModule];
 				$wfvals['workflow_id'] = 0;
 				$wfvals['defaultworkflow'] = 0;
 				$wfvals['summary'] = '';

--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -1636,7 +1636,8 @@ class CRMEntity {
 	 */
 	public function getQueryByModuleField($module, $fieldname, $srcrecord, $query = '') {
 		global $adb;
-		$bmapname = $module.'_ListColumns';
+		$relatedModule = vtlib_purify($_REQUEST['module']);
+		$bmapname = $relatedModule.'_ListColumns';
 		$cbMapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 		if ($cbMapid) {
 			$cbMap = cbMap::getMapByID($cbMapid);
@@ -1651,8 +1652,12 @@ class CRMEntity {
 				$query_body = substr($query, 0, $wherepos);
 				$workflowScheduler = new WorkFlowScheduler($adb);
 				$workflow = new Workflow();
-				$wfvals['module_name'] = $module;
+				$wfvals['module_name'] = $relatedModule;
 				$wfvals['test'] = $conditions[$fieldname];
+				$wfvals['workflow_id'] = 0;
+				$wfvals['defaultworkflow'] = 0;
+				$wfvals['summary'] = '';
+				$wfvals['execution_condition'] = '';
 				$workflow->setup($wfvals);
 				$query = $workflowScheduler->getWorkflowQuery($workflow, array_values($fields));
 				$wherepos = stripos($query, ' where ');

--- a/data/CRMEntity.php
+++ b/data/CRMEntity.php
@@ -1637,7 +1637,7 @@ class CRMEntity {
 	public function getQueryByModuleField($module, $fieldname, $srcrecord, $query = '') {
 		global $adb;
 		$relatedModule = vtlib_purify($_REQUEST['module']);
-		$bmapname = $relatedModule.'_ListColumns';
+		$bmapname = $module.'_ListColumns';
 		$cbMapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 		if ($cbMapid) {
 			$cbMap = cbMap::getMapByID($cbMapid);

--- a/include/utils/ListViewUtils.php
+++ b/include/utils/ListViewUtils.php
@@ -274,8 +274,14 @@ function getSearchListViewHeader($focus, $module, $sort_qry = '', $sorder = '', 
 	$cbMapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 	if ($cbMapid) {
 		$cbMap = cbMap::getMapByID($cbMapid);
-		$focus->search_fields = $cbMap->ListColumns()->getSearchFields();
-		$focus->search_fields_name = $cbMap->ListColumns()->getSearchFieldsName();
+		$SearchFields = $cbMap->ListColumns()->getSearchFields();
+		$SearchFieldsName = $cbMap->ListColumns()->getSearchFieldsName();
+		if (!empty($SearchFields)) {
+			$focus->search_fields = $SearchFields;
+		}
+		if (!empty($SearchFieldsName)) {
+			$focus->search_fields_name = $SearchFieldsName;
+		}
 	}
 	$field_list = array_values($focus->search_fields_name);
 	$userprivs = $current_user->getPrivileges();
@@ -909,8 +915,14 @@ function getSearchListViewEntries($focus, $module, $list_result, $navigation_arr
 	$cbMapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 	if ($cbMapid) {
 		$cbMap = cbMap::getMapByID($cbMapid);
-		$focus->search_fields = $cbMap->ListColumns()->getSearchFields();
-		$focus->search_fields_name = $cbMap->ListColumns()->getSearchFieldsName();
+		$SearchFields = $cbMap->ListColumns()->getSearchFields();
+		$SearchFieldsName = $cbMap->ListColumns()->getSearchFieldsName();
+		if (!empty($SearchFields)) {
+			$focus->search_fields = $cbMap->ListColumns()->getSearchFields();
+		}
+		if (!empty($SearchFieldsName)) {
+			$focus->search_fields_name = $cbMap->ListColumns()->getSearchFieldsName();
+		}
 		$focus->popup_fields = array($cbMap->ListColumns()->getSearchLinkField());
 		$focus->list_link_field = $cbMap->ListColumns()->getSearchLinkField();
 	}


### PR DESCRIPTION
This is an enhance of Popup query hook (previously done for fields), now we can use conditions directly in a ListColumns map to filter records between 2 modules in a related list popup view. This map is an example of relation of Accounts with Documents, and we filter records of Documents only when we open the Popup in Accounts module.
* Map (conditions for related modules in related lists view):
* MapName: `Accounts_ListColumns`
```xml
<map>
	<originmodule>
		<originname>Accounts</originname>
	</originmodule>
	<popup>
		<conditions>
			<condition>
				<formodule>Accounts</formodule>
				<relatedmodule>Documents</relatedmodule>
				<value>[{"fieldname":"filename","operation":"contains","value":"t","valuetype":"rawtext","joincondition":"or","groupid":"0"}]</value>
			</condition>
		</conditions>
	</popup>
</map>
```