### PR TITLE
fix(ListView) resolve error when recordId is not given in BusinessActions

### DIFF
--- a/modules/cbQuestion/cbQuestionWidget.php
+++ b/modules/cbQuestion/cbQuestionWidget.php
@@ -43,7 +43,7 @@ class bqAnswer_DetailViewBlock extends DeveloperBlock {
 				'$MODULE$' => $module,
 				'$USERID$' => $current_user->id,
 			);
-			if (isset($recordid) && $recordid != '0x0') {
+			if (isset($recordid) && $recordid != '0x0' && !empty($recordid)) {
 				$ctxtmodule = getSalesEntityType($recordid);
 				$params['$MODULE$'] = $ctxtmodule;
 				$ent = CRMEntity::getInstance($ctxtmodule);

--- a/modules/cbQuestion/cbQuestionWidget.php
+++ b/modules/cbQuestion/cbQuestionWidget.php
@@ -43,7 +43,7 @@ class bqAnswer_DetailViewBlock extends DeveloperBlock {
 				'$MODULE$' => $module,
 				'$USERID$' => $current_user->id,
 			);
-			if (isset($recordid) && $recordid != '0x0' && !empty($recordid)) {
+			if (!empty($recordid) && $recordid != '0x0') {
 				$ctxtmodule = getSalesEntityType($recordid);
 				$params['$MODULE$'] = $ctxtmodule;
 				$ent = CRMEntity::getInstance($ctxtmodule);


### PR DESCRIPTION
BA issue in ListView....when the BA calls a business question it needs a specific record id to work.. here is an image if we don't set a specific record id, the list view doesn't get loaded: ![image](https://skhr.spike.studio/storage/2022/September/week4/361531__2022-09-28_image.png) the business question: https://ncarefit.evolutivo.it/index.php?module=cbQuestion&action=DetailView&record=8616 the business action: block://bqanswer:modules/cbQuestion/cbQuestionWidget.php:QID=8616&RECORDID=8551

