### PR TITLE
fix(PopupFilter) deep cloning the arr object

### DIFF
--- a/include/js/vtlib.js
+++ b/include/js/vtlib.js
@@ -128,6 +128,7 @@ function popup_filter_map_popup_window(fldname) {
  * yes it replaces it with the record's field value
 */
 function replaceDynamicVariableWithRecordValue(arr) {
+	let array = structuredClone(arr);
 	const formTypes = ['EditView', 'DetailView'];
 	for (let index = 0; index < formTypes.length; index++) {
 		const formType = formTypes[index];
@@ -138,17 +139,17 @@ function replaceDynamicVariableWithRecordValue(arr) {
 			} else {
 				formValues = getDetailViewFormFields();
 			}
-			for (let index = 0; index < arr.length; index++) {
-				const element = arr[index];
+			for (let index = 0; index < array.length; index++) {
+				const element = array[index];
 				if (element['value'].includes('$')) {
 					let value = element['value'].substr(1);
 					element['value'] = formValues[value];
 				}
 			}
-			return arr;
+			return array;
 		}
 	}
-	return arr;
+	return array;
 }
 
 /**


### PR DESCRIPTION
The nature of javascript is to treat variables that are objects and arrays as refrences (pointers) when passed as a function parameter. That led to mutating the original array. which had unexpected behavior. The issue was fixed by deeply cloning the array using the structuredClone() function. This function clones the array itself and all the objects inside of it. Because cloning the array alone and keeping the same value (in this case they are objects' refrences) inside of it is not sufficient to prevent mutating the original variable. 