### PR TITLE
fix(PopupFilter) make popup_filter_map_popup_window return value not promise

### DIFF
--- a/Popup.php
+++ b/Popup.php
@@ -424,6 +424,18 @@ if (isset($_REQUEST['cbcustompopupinfo'])) {
 	$smarty->assign('CBCUSTOMPOPUPINFO', $_REQUEST['cbcustompopupinfo']);
 }
 
+// sending PopupFilter map results to the frontEnd
+$bmapname = $currentModule.'_PopupFilter';
+$Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
+if ($Mapid) {
+	$MapObject = new cbMap();
+	$MapObject->id = $Mapid;
+	$MapObject->mode = '';
+	$MapObject->retrieve_entity_info($Mapid, "cbMap");
+	$MapResult = $MapObject->PopupFilter($record, $currentModule);
+	$smarty->assign('PopupFilterMapResults', $MapResult);
+}
+
 if (isset($_REQUEST['ajax']) && $_REQUEST['ajax'] != '') {
 	$smarty->display('PopupContents.tpl');
 } else {

--- a/include/js/vtlib.js
+++ b/include/js/vtlib.js
@@ -96,7 +96,7 @@ function vtlib_open_popup_window(fromlink, fldname, MODULE, ID) {
 /*
 * Generic uitype popup open action for popup filter map
 */
-async function popup_filter_map_popup_window(fldname) {
+function popup_filter_map_popup_window(fldname) {
 	if (typeof PopupFilterMapResults == 'undefined') {
 		return false;
 	}
@@ -104,17 +104,25 @@ async function popup_filter_map_popup_window(fldname) {
 	const keys = Object.keys(PopupFilterMapResults);
 	for (let index = 0; index < keys.length; index++) {
 		const key = keys[index];
-		let advft_criteria = JSON.stringify(await replaceDynamicVariableWithRecordValue(PopupFilterMapResults[key]['advft_criteria']));
-		let advft_criteria_groups = JSON.stringify(PopupFilterMapResults[key]['advft_criteria_groups']);
 		if (key.includes('#')) {
 			let [fieldName, dependency] = key.split('#');
 			if (fieldName == fldname && dependency == fieldModule) {
-				window.open('index.php?module=' + fieldModule + '&action=Popup&html=Popup_picker&form=DetailView&forfield=' + fldname + '&query=true&search=true&searchtype=advance&advft_criteria=' + advft_criteria + '&advft_criteria_groups=' + advft_criteria_groups, 'vtlibui10qc', cbPopupWindowSettings);
+				replaceDynamicVariableWithRecordValue(PopupFilterMapResults[key]['advft_criteria'])
+				.then((recordValue) => {
+					let advft_criteria = JSON.stringify(recordValue);
+					let advft_criteria_groups = JSON.stringify(PopupFilterMapResults[key]['advft_criteria_groups']);
+					window.open('index.php?module=' + fieldModule + '&action=Popup&html=Popup_picker&form=DetailView&forfield=' + fldname + '&query=true&search=true&searchtype=advance&advft_criteria=' + advft_criteria + '&advft_criteria_groups=' + advft_criteria_groups, 'vtlibui10qc', cbPopupWindowSettings);
+				});
 				return true;
 			}
 		} else {
 			if (key == fldname) {
-				window.open('index.php?module=' + fieldModule + '&action=Popup&html=Popup_picker&form=DetailView&forfield=' + fldname + '&query=true&search=true&searchtype=advance&advft_criteria=' + advft_criteria + '&advft_criteria_groups=' + advft_criteria_groups, 'vtlibui10qc', cbPopupWindowSettings);
+				replaceDynamicVariableWithRecordValue(PopupFilterMapResults[key]['advft_criteria'])
+				.then((recordValue) => {
+					let advft_criteria = JSON.stringify(recordValue);
+					let advft_criteria_groups = JSON.stringify(PopupFilterMapResults[key]['advft_criteria_groups']);
+					window.open('index.php?module=' + fieldModule + '&action=Popup&html=Popup_picker&form=DetailView&forfield=' + fldname + '&query=true&search=true&searchtype=advance&advft_criteria=' + advft_criteria + '&advft_criteria_groups=' + advft_criteria_groups, 'vtlibui10qc', cbPopupWindowSettings);
+				});
 				return true;
 			}
 		}

--- a/modules/Contacts/EditView.php
+++ b/modules/Contacts/EditView.php
@@ -278,10 +278,10 @@ $smarty->assign('SHOW_COPY_ADDRESS', GlobalVariable::getVariable('Application_Sh
 $smarty->display('salesEditView.tpl');
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/Documents/DetailView.php
+++ b/modules/Documents/DetailView.php
@@ -197,10 +197,10 @@ $smarty->assign('DETAILVIEW_AJAX_EDIT', GlobalVariable::getVariable('Application
 $smarty->display('DetailView.tpl');
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/Documents/EditView.php
+++ b/modules/Documents/EditView.php
@@ -358,10 +358,10 @@ $smarty->assign('Application_Textarea_Style', GlobalVariable::getVariable('Appli
 $smarty->display('salesEditView.tpl');
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/Invoice/EditView.php
+++ b/modules/Invoice/EditView.php
@@ -508,10 +508,10 @@ if (empty($associated_prod) && GlobalVariable::getVariable('Inventory_Check_Invo
 }
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/Products/EditView.php
+++ b/modules/Products/EditView.php
@@ -329,10 +329,10 @@ $smarty->assign('Application_Textarea_Style', GlobalVariable::getVariable('Appli
 $smarty->display('Inventory/InventoryEditView.tpl');
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/PurchaseOrder/EditView.php
+++ b/modules/PurchaseOrder/EditView.php
@@ -333,10 +333,10 @@ $smarty->assign('ShowInventoryLines', strpos(GlobalVariable::getVariable('Invent
 $smarty->display('Inventory/InventoryEditView.tpl');
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/Quotes/EditView.php
+++ b/modules/Quotes/EditView.php
@@ -364,10 +364,10 @@ $smarty->assign('ShowInventoryLines', strpos(GlobalVariable::getVariable('Invent
 $smarty->display('Inventory/InventoryEditView.tpl');
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/SalesOrder/EditView.php
+++ b/modules/SalesOrder/EditView.php
@@ -460,10 +460,10 @@ $smarty->assign('ShowInventoryLines', strpos(GlobalVariable::getVariable('Invent
 $smarty->display('Inventory/InventoryEditView.tpl');
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/Services/EditView.php
+++ b/modules/Services/EditView.php
@@ -266,10 +266,10 @@ $smarty->assign('Application_Textarea_Style', GlobalVariable::getVariable('Appli
 $smarty->display('Inventory/InventoryEditView.tpl');
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/Vtiger/DetailView.php
+++ b/modules/Vtiger/DetailView.php
@@ -181,10 +181,10 @@ $smarty->assign('DETAILVIEW_AJAX_EDIT', GlobalVariable::getVariable('Application
 $smarty->assign('Application_Textarea_Style', GlobalVariable::getVariable('Application_Textarea_Style', 'height:140px;', $currentModule, $current_user->id));
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/Vtiger/EditView.php
+++ b/modules/Vtiger/EditView.php
@@ -217,10 +217,10 @@ $smarty->assign('FIELD_DEPENDENCY_DATASOURCE', json_encode($cbMapFDEP));
 $smarty->assign('Application_Textarea_Style', GlobalVariable::getVariable('Application_Textarea_Style', 'height:140px;', $currentModule, $current_user->id));
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/cbCalendar/DetailView.php
+++ b/modules/cbCalendar/DetailView.php
@@ -149,10 +149,10 @@ if ($activitytype == 'Emails') {
 }
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");

--- a/modules/cbCalendar/EditView.php
+++ b/modules/cbCalendar/EditView.php
@@ -198,10 +198,10 @@ if ($record && cbCalendar::getCalendarActivityType($record)=='Emails') {
 }
 
 // sending PopupFilter map results to the frontEnd
-$MapObject = new cbMap();
 $bmapname = $currentModule.'_PopupFilter';
 $Mapid = GlobalVariable::getVariable('BusinessMapping_'.$bmapname, cbMap::getMapIdByName($bmapname));
 if ($Mapid) {
+	$MapObject = new cbMap();
 	$MapObject->id = $Mapid;
 	$MapObject->mode = '';
 	$MapObject->retrieve_entity_info($Mapid, "cbMap");


### PR DESCRIPTION
async functions always return a promise. so the popup_filter_map_popup_window does not return the boolean values unless ***await*** is used with it. the solution is to remove the async keyword from the function and to return the boolean value immediately once the condition is met. after the boolean value is returned the promise will be executed and it will fetch the results from the backend and then open the popup.