### PR TITLE
fix(PopupFilter) not keeping json filter results after quick create

### DIFF
--- a/Smarty/templates/QuickCreateHidden.tpl
+++ b/Smarty/templates/QuickCreateHidden.tpl
@@ -15,7 +15,7 @@
 	<input type="hidden" name="from" value="{$FROM}">
 	<input type="hidden" name="return_action" value="Popup">
 	<input type="hidden" name="return_module" value="{$MODULE}">
-	<input type="hidden" name="search_url" value="{$URLPOPUP}">
+	<input type="hidden" name="search_url" value="{$URLPOPUP|replace:'"':'%22'}">
 {/if}
 	<input type="hidden" name="module" value="{$MODULE}">
 	<input type="hidden" name="record" value="">


### PR DESCRIPTION
when we try to create a quick record from popupFilter and submit the creation form the popup refreshes but does not keep the filter state. the issue was that json uses quates (") but quates are used also in html element attributes. that leads the url to break.
![image](https://user-images.githubusercontent.com/59079190/213227121-6580a0a9-0084-484d-9735-73776c7cfe37.png)
