### PR TITLE
fix(Tui-grid-table) table header overlapping when columns names are t…

### DIFF
--- a/include/style.css
+++ b/include/style.css
@@ -100,6 +100,11 @@
   border: 1px solid #ddd;
 }
 
+.detailview_wrapper_table .tui-grid-header-area,
+#RLContents  .tui-grid-header-area {
+  height: auto !important;
+}
+
 .detailview_wrapper_table .tui-grid-table .tui-grid-cell,
 #RLContents .tui-grid-table .tui-grid-cell {
   border: 1px solid #ddd;


### PR DESCRIPTION
Fixing the column header:
![image](https://user-images.githubusercontent.com/23297883/213688261-e50935cc-fe80-4a4e-9954-1a23c5944fe0.png)
