### PR TITLE
feat(expression) support expression inside strings

### DIFF
--- a/modules/com_vtiger_workflow/VTWorkflowUtils.php
+++ b/modules/com_vtiger_workflow/VTWorkflowUtils.php
@@ -59,7 +59,7 @@ class VTWorkflowUtils {
 			if (trim($fieldValue)=='') {
 				$fieldValue = '';
 			} else {
-				$parser = new VTExpressionParser(new VTExpressionSpaceFilter(new VTExpressionTokenizer($fieldValue)));
+				$parser = new VTExpressionParser(new VTExpressionSpaceFilter(new VTExpressionTokenizer($fieldValue, $entity)));
 				$expression = $parser->expression();
 				$exprEvaluater = new VTFieldExpressionEvaluater($expression);
 				$fieldValue = $exprEvaluater->evaluate($entity);

--- a/modules/com_vtiger_workflow/evaluateit.php
+++ b/modules/com_vtiger_workflow/evaluateit.php
@@ -43,7 +43,7 @@ switch ($exptype) {
 			$entityId = vtws_getEntityId($crmmod).'x'.$crmid;
 			$entity = new VTWorkflowEntity($adminUser, $entityId);
 			try {
-				$parser = new VTExpressionParser(new VTExpressionSpaceFilter(new VTExpressionTokenizer(rawurldecode($exp))));
+				$parser = new VTExpressionParser(new VTExpressionSpaceFilter(new VTExpressionTokenizer(rawurldecode($exp), $entity)));
 				$expression = $parser->expression();
 				$exprEvaluater = new VTFieldExpressionEvaluater($expression);
 				$msg = $exprEvaluater->evaluate($entity);

--- a/modules/com_vtiger_workflow/expression_engine/VTTokenizer.inc
+++ b/modules/com_vtiger_workflow/expression_engine/VTTokenizer.inc
@@ -24,8 +24,13 @@ function _vt_processtoken_symbol($token) {
 
 class VTExpressionTokenizer {
 
-	public function __construct($expr) {
+	public function __construct($expr, $entity = null) {
 		global $default_charset;
+
+		if ($entity) {
+			$expr = $this->recursiveExpressionHandler($expr, $entity);
+		}
+
 		$tokenTypes = array(
 			"SPACE" => array('\s+', '_vt_processtoken_id'),
 			"SYMBOL" => array('[a-zA-Z][\w]*', '_vt_processtoken_symbol'),
@@ -90,6 +95,33 @@ class VTExpressionTokenizer {
 			$token->value = $this->tokenTypes[$tokenName][1]($match[$i]);
 			return $token;
 		}
+	}
+
+	public function recursiveExpressionHandler($expr, $entity) {
+		$from = 0;
+		$to = 0;
+		$level = 0;
+		for ($i=0; $i < strlen($expr); $i++) {
+			if ($expr[$i] == "{") {
+				$level++;
+				if ($level == 1) {
+					$from = $i;
+				}
+			} elseif ($expr[$i] == "}") {
+				if ($level == 1) {
+					$to = $i;
+					$internalExpression = substr($expr, $from + 1, $to - $from - 1);
+					$parser = new VTExpressionParser(new VTExpressionSpaceFilter(new VTExpressionTokenizer($internalExpression, $entity)));
+					$expression = $parser->expression();
+					$exprEvaluater = new VTFieldExpressionEvaluater($expression);
+					$value = $exprEvaluater->evaluate($entity);
+					$expr = substr_replace($expr, $value, $from, ($to - $from) + 1);
+					$i = $from;
+				}
+				$level--;
+			}
+		}
+		return $expr;
 	}
 }
 

--- a/modules/com_vtiger_workflow/expression_engine/VTTokenizer.inc
+++ b/modules/com_vtiger_workflow/expression_engine/VTTokenizer.inc
@@ -102,12 +102,12 @@ class VTExpressionTokenizer {
 		$to = 0;
 		$level = 0;
 		for ($i=0; $i < strlen($expr); $i++) {
-			if ($expr[$i] == "{") {
+			if ($expr[$i] == "{" && $expr[$i + 1] == "{") {
 				$level++;
 				if ($level == 1) {
 					$from = $i;
 				}
-			} elseif ($expr[$i] == "}") {
+			} elseif ($expr[$i] == "}" && $expr[$i + 1] == "}") {
 				if ($level == 1) {
 					$to = $i;
 					$internalExpression = substr($expr, $from + 1, $to - $from - 1);
@@ -115,7 +115,7 @@ class VTExpressionTokenizer {
 					$expression = $parser->expression();
 					$exprEvaluater = new VTFieldExpressionEvaluater($expression);
 					$value = $exprEvaluater->evaluate($entity);
-					$expr = substr_replace($expr, $value, $from, ($to - $from) + 1);
+					$expr = substr_replace($expr, $value, $from, ($to - $from) + 2);
 					$i = $from;
 				}
 				$level--;


### PR DESCRIPTION
## Support expression inside strings

You can use curly brackets  `{ expression }` to write valid expressions inside strings. This feature made for long string parameters like the condition parameter of the aggregation function. That parameter supports selecting uitype10 fields but it does not support the usage of normal expression functions.
Inspired by javascript [Template Literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals)


### Features
* Works inside strings
* Supports nesting
* Works outside strings too (similar to a Preprocessor in c/c++)

### Examples
![image](https://user-images.githubusercontent.com/59079190/213919045-99eb4f4f-86fd-4342-9e50-de35125101c8.png)
![image](https://user-images.githubusercontent.com/59079190/213919420-a1b1f22e-9817-4f79-91e9-12a45263cd6a.png)
![image](https://user-images.githubusercontent.com/59079190/213919471-eb617ecf-a613-43b1-b5b6-3bf2eb815f9e.png)
![image](https://user-images.githubusercontent.com/59079190/213919542-e9dd4a31-3c35-4f61-9da5-d86efeebdbf2.png)

