### PR TITLE
feat(cbCVManagement) add support for user private filters

### DIFF
--- a/Smarty/templates/CustomView.tpl
+++ b/Smarty/templates/CustomView.tpl
@@ -108,21 +108,21 @@ function mandatoryCheck() {
 					<td class="dvtCellInfo" width="30%">
 						<input class="detailedViewTextBox" type="text" name='viewName' value="{if isset($VIEWNAME)}{$VIEWNAME}{/if}" onfocus="this.className='detailedViewTextBoxOn'" onblur="this.className='detailedViewTextBox'" size="40" {if $PERMITALL eq 'true'}disabled{/if}/>
 					</td>
-					<td class="dvtCellInfo" width="20%">
+					<td class="dvtCellInfo" width="15%">
 					{if $CHECKED eq 'checked'}
 						<input type="checkbox" name="setDefault" value="1" checked {if $PERMITALL eq 'true'}disabled{/if} />{$MOD.LBL_SETDEFAULT}
 					{else}
 						<input type="checkbox" name="setDefault" value="0" {if $PERMITALL eq 'true'}disabled{/if} />{$MOD.LBL_SETDEFAULT}
 					{/if}
 					</td>
-					<td class="dvtCellInfo" width="20%">
+					<td class="dvtCellInfo" width="15%">
 					{if $MCHECKED eq 'checked'}
 						<input type="checkbox" name="setMetrics" value="1" checked {if $PERMITALL eq 'true'}disabled{/if} />{$MOD.LBL_LIST_IN_METRICS}
 					{else}
 						<input type="checkbox" name="setMetrics" value="0" {if $PERMITALL eq 'true'}disabled{/if} />{$MOD.LBL_LIST_IN_METRICS}
 					{/if}
 					</td>
-					<td class="dvtCellInfo" width="20%">
+					<td class="dvtCellInfo" width="15%">
 					{if $PERMITALL eq 'true'}
 						<input type="checkbox" name="setStatus" value="0" checked {if $PERMITALL eq 'true'}disabled{/if} />
 					{else}
@@ -135,6 +135,14 @@ function mandatoryCheck() {
 						{/if}
 					{/if}
 						{$MOD.LBL_SET_AS_PUBLIC}
+					</td>
+					<td class="dvtCellInfo" width="15%">
+						{if isset($setPrivate)}
+							<input type="checkbox" name="setPrivate" value="1" {$setPrivate} />
+						{else}
+							<input type="checkbox" name="setPrivate" value="1" />
+						{/if}
+						{$MOD.LBL_SET_AS_PRIVATE}
 					</td>
 				</tr>
 			</table>

--- a/build/changeSets/2023/addIsPrivateFieldToCbCVManagement.php
+++ b/build/changeSets/2023/addIsPrivateFieldToCbCVManagement.php
@@ -1,0 +1,44 @@
+<?php
+/*************************************************************************************************
+ * Copyright 2022 Spike, JPL TSolucio, S.L. -- This file is a part of TSOLUCIO coreBOS Customizations.
+ * Licensed under the vtiger CRM Public License Version 1.1 (the "License"); you may not use this
+ * file except in compliance with the License. You can redistribute it and/or modify it
+ * under the terms of the License. JPL TSolucio, S.L. reserves all rights not expressly
+ * granted by the License. coreBOS distributed by JPL TSolucio S.L. is distributed in
+ * the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Unless required by
+ * applicable law or agreed to in writing, software distributed under the License is
+ * distributed on an "AS IS" BASIS, WITHOUT ANY WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License. You may obtain a copy of the License
+ * at <http://corebos.org/documentation/doku.php?id=en:devel:vpl11>
+ *************************************************************************************************/
+
+class addIsPrivateFieldToCbCVManagement extends cbupdaterWorker {
+
+	public function applyChange() {
+		if ($this->hasError()) {
+			$this->sendError();
+		}
+		if ($this->isApplied()) {
+			$this->sendMsg('Changeset ' . get_class($this) . ' already applied!');
+		} else {
+			$fields = array(
+				'cbCVManagement' => array(
+					'LBL_CVMGMT_DEFAULTS' => array(
+						'setprivate' => array(
+							'columntype'=>'int(3)',
+							'typeofdata'=>'C~O',
+							'uitype'=>56,
+							'label' => 'Set Private'
+						),
+					),
+				),
+			);
+			$this->massCreateFields($fields);
+			$this->sendMsg('Changeset ' . get_class($this) . ' applied!');
+			$this->markApplied(false);
+		}
+		$this->finishExecution();
+	}
+}

--- a/modules/CustomView/EditView.php
+++ b/modules/CustomView/EditView.php
@@ -88,6 +88,7 @@ if ($recordid == '') {
 		if ($customviewdtls['setmetrics'] == 1) {
 			$smarty->assign('MCHECKED', 'checked');
 		}
+		$smarty->assign('setPrivate', $customviewdtls['setPrivate'] ? 'checked' : '');
 		$status = $customviewdtls['status'];
 		$smarty->assign('STATUS', $status);
 		$choosecolslist = $oCustomView->getByModule_ColumnsList($modulecollist);

--- a/modules/CustomView/Save.php
+++ b/modules/CustomView/Save.php
@@ -451,13 +451,14 @@ if ($cvmodule != '') {
 		'cvdefault' => $setdefault,
 		'cvapprove' =>'0',
 		'setpublic' => $setpublic,
+		'setprivate' => isset($_REQUEST['setPrivate']) ? 1 : 0,
 		'mandatory' => '0',
 		'module_list' => $cvmodule,
 		'assigned_user_id' => vtws_getEntityId('Users').'x'.$current_user->id,
 		'cvrole' => $subrole
 	);
 	$searchOn = 'cvid';
-	$updatedfields = 'cvdefault,setpublic';
+	$updatedfields = 'cvdefault,setpublic,setprivate';
 	vtws_upsert('cbCVManagement', $default_values, $searchOn, $updatedfields, $current_user);
 }
 

--- a/modules/CustomView/language/en_us.lang.php
+++ b/modules/CustomView/language/en_us.lang.php
@@ -251,6 +251,7 @@ $mod_strings = array(
 
 //Added for Role based Custom filters
 'LBL_SET_AS_PUBLIC'=>'Set as Public ',
+'LBL_SET_AS_PRIVATE'=>'Set as Private',
 'LBL_NEW'=>'New',
 'LBL_EDIT'=>'Edit',
 'LBL_STATUS_PUBLIC_APPROVE'=>'Approve',

--- a/modules/CustomView/language/es_es.lang.php
+++ b/modules/CustomView/language/es_es.lang.php
@@ -261,6 +261,7 @@ $mod_strings = array (
 
 //Added for Role based Custom filters
 'LBL_SET_AS_PUBLIC'=>'Hacer Público ',
+'LBL_SET_AS_PRIVATE'=>'Set as Private',
 'LBL_NEW'=>'Nuevo',
 'LBL_EDIT'=>'Editar',
 'LBL_STATUS_PUBLIC_APPROVE'=>'Aprobar',

--- a/modules/CustomView/language/it_it.lang.php
+++ b/modules/CustomView/language/it_it.lang.php
@@ -230,6 +230,7 @@ $mod_strings = array (
 	'between' => 'Tra',
 
 	'LBL_SET_AS_PUBLIC' => 'Imposta a Pubblico ',
+	'LBL_SET_AS_PRIVATE'=>'Set as Private',
 	'LBL_NEW' => 'Nuovo',
 	'LBL_EDIT' => 'Modifica',
 	'LBL_STATUS_PUBLIC_APPROVE' => 'Approva',

--- a/modules/cbCVManagement/cbCVManagement.php
+++ b/modules/cbCVManagement/cbCVManagement.php
@@ -403,6 +403,23 @@ class cbCVManagement extends CRMEntity {
 				$allViews[] = $value['cvid'];
 			}
 		}
+
+		// // filter private records views
+		// $cvsql = 'SELECT vtiger_cbcvmanagement.cvid, vtiger_customview.userid 
+		// 	FROM `vtiger_cbcvmanagement` 
+		// 	INNER JOIN vtiger_customview 
+		// 	ON vtiger_cbcvmanagement.cvid = vtiger_customview.cvid 
+		// 	WHERE setprivate = 1';
+		// $queryResult = $adb->query($cvsql);
+		// while ($row=$adb->fetch_array($queryResult)) {
+		// 	for ($i=0; $i < count($allViews); $i++) {
+		// 		if ($allViews[$i] == $row['cvid'] && $row['userid'] !== $cvuserid) {
+		// 			unset($allViews[$i]);
+		// 			$allViews = array_values($allViews);
+		// 		}
+		// 	}
+		// }
+
 		VTCacheUtils::updateCachedInformation($key, $value);
 		return array_unique($allViews);
 	}
@@ -478,6 +495,22 @@ class cbCVManagement extends CRMEntity {
 		if (empty($cvuserid)) {
 			return false;
 		}
+
+		// // checks if the record is Private
+		// $cvsql = 'SELECT vtiger_cbcvmanagement.cvid, vtiger_customview.userid 
+		// 	FROM `vtiger_cbcvmanagement` 
+		// 	INNER JOIN vtiger_customview 
+		// 	ON vtiger_cbcvmanagement.cvid = vtiger_customview.cvid 
+		// 	WHERE setprivate = 1 AND vtiger_cbcvmanagement.cvid = ? AND vtiger_customview.userid != ?';
+		// global $log;
+		// $log->fatal('OOOOOOOOOOOOOOOOOOPPPPPPPPPPPPPPPPPPPPP');
+		// $log->fatal($cvsql);
+		// $log->fatal(array($cvid, $cvuserid));
+		// $queryResult = $adb->pquery($cvsql, array($cvid, $cvuserid));
+		// if ($adb->num_rows($queryResult)) {
+		// 	return array('C' => 0, 'R' => 0, 'U' => 0, 'D' => 0, 'A' => 0);
+		// }
+
 		$module = $adb->query_result($cvrs, 0, 'entitytype');
 		$cvname = $adb->query_result($cvrs, 0, 'viewname');
 		$cvuid = $adb->query_result($cvrs, 0, 'userid');
@@ -604,6 +637,26 @@ class cbCVManagement extends CRMEntity {
 
 	public static function getValidationInfo() {
 		return self::$validationinfo;
+	}
+
+	public static function getSetPrivateByCvId($cvid) {
+		global $adb;
+		$result = $adb->pquery("SELECT setprivate FROM `vtiger_cbcvmanagement` WHERE cvid = ?", array($cvid));
+		if (!$result) {
+			return false;
+		}
+		return $result->fields['setprivate'];
+	}
+
+	public static function getFilterViewPermission($record_id) {
+		global $adb;
+		$rs = $adb->pquery('select * from vtiger_cbcvmanagement inner join vtiger_crmentity on crmid=cbcvmanagementid where deleted=0 and cvid=?', array(
+			$record_id
+		));
+		if ($adb->num_rows($rs) == 1) {
+			return array_filter($rs->FetchRow(), 'is_string', ARRAY_FILTER_USE_KEY);
+		}
+		return false;
 	}
 }
 ?>

--- a/modules/cbupdater/cbupdates/2023.xml
+++ b/modules/cbupdater/cbupdates/2023.xml
@@ -42,4 +42,11 @@
 	<classname>addBAforMasterDetail</classname>
 	<systemupdate>true</systemupdate>
 </changeSet>
+<changeSet>
+	<author>maliknajjar</author>
+	<description>add set private field for View Permissions module</description>
+	<filename>build/changeSets/2023/addIsPrivateFieldToCbCVManagement.php</filename>
+	<classname>addIsPrivateFieldToCbCVManagement</classname>
+	<systemupdate>true</systemupdate>
+</changeSet>
 </updatesChangeLog>


### PR DESCRIPTION
## add support for user private filters
- we want to have the possibility to create private filters based on the user.
- So only the user who created the filter can view, edit and delete it.
- Add checkbox: 'Set Private' on filter creation view in order to set it visible only for that specified user.

![image](https://user-images.githubusercontent.com/59079190/215463329-f204fd68-6a64-4f85-bf2d-4c6cbf61bccd.png)