### PR TITLE
Business Question Direct Sql

### DIFF
--- a/build/changeSets/2023/addBQforDirectSql.php
+++ b/build/changeSets/2023/addBQforDirectSql.php
@@ -1,0 +1,35 @@
+<?php
+/*************************************************************************************************
+ * Copyright 2023 JPL TSolucio, S.L. -- This file is a part of TSOLUCIO coreBOS Customizations.
+* Licensed under the vtiger CRM Public License Version 1.1 (the "License"); you may not use this
+* file except in compliance with the License. You can redistribute it and/or modify it
+* under the terms of the License. JPL TSolucio, S.L. reserves all rights not expressly
+* granted by the License. coreBOS distributed by JPL TSolucio S.L. is distributed in
+* the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+* warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. Unless required by
+* applicable law or agreed to in writing, software distributed under the License is
+* distributed on an "AS IS" BASIS, WITHOUT ANY WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the specific language governing
+* permissions and limitations under the License. You may obtain a copy of the License
+* at <http://corebos.org/documentation/doku.php?id=en:devel:vpl11>
+*************************************************************************************************/
+class addBQforDirectSql extends cbupdaterWorker {
+	public function applyChange() {
+		if ($this->hasError()) {
+			$this->sendError();
+		}
+		if ($this->isApplied()) {
+			$this->sendMsg('Changeset '.get_class($this).' already applied!');
+		} else {
+			$module = Vtiger_Module::getInstance('cbQuestion');
+			$field = Vtiger_Field::getInstance('querytype', $module);
+			if ($field) {
+				$field->setPicklistValues(array('Direct Sql'));
+			}
+			$this->sendMsg('Changeset '.get_class($this).' applied!');
+			$this->markApplied(false);
+		}
+		$this->finishExecution();
+	}
+}
+?>

--- a/modules/cbQuestion/cbQuestion.js
+++ b/modules/cbQuestion/cbQuestion.js
@@ -91,3 +91,24 @@ function cbqexecutescript(tablename, qid, script_path) {
 		document.getElementById('appnotifydiv').style.display='block';
 	});
 }
+
+window.addEventListener("DOMContentLoaded",(e) => {
+	const el = document.getElementById("querytype");
+	el.addEventListener("change", function(e){
+	if(el.value == 'Direct Sql'){
+		const txtcolumn = document.getElementById("qcondition");
+		const txtorderby = document.getElementById("orderby");
+		const txtgroupby = document.getElementById("groupby");
+		txtcolumn.disabled = true;
+		txtorderby.disabled = true;
+		txtgroupby.disabled = true;
+		txtcolumn.setAttribute("class", "blury");
+		txtcolumn.style.backgroundColor = "#D3D3D3";
+		txtorderby.setAttribute("class", "blury");
+		txtorderby.style.backgroundColor = "#D3D3D3";
+		txtgroupby.setAttribute("class", "blury");
+		txtgroupby.style.backgroundColor = "#D3D3D3";
+	}
+});
+})
+

--- a/modules/cbQuestion/cbQuestion.php
+++ b/modules/cbQuestion/cbQuestion.php
@@ -223,7 +223,10 @@ class cbQuestion extends CRMEntity {
 				$query .= ' LIMIT '.$q->column_fields['qpagesize'];
 			}
 			$query .= ';';
-		} else {
+		} else if ($q->column_fields['querytype'] == 'SQL') {
+			$query = decode_html($q->column_fields['qcolumns']);
+		}
+		else {
 			$chkrs = $adb->pquery(
 				'SELECT 1 FROM (select name from `vtiger_ws_entity` UNION select name from vtiger_tab) as tnames where name=?',
 				array($q->column_fields['qmodule'])

--- a/modules/cbQuestion/language/en_us.lang.php
+++ b/modules/cbQuestion/language/en_us.lang.php
@@ -112,5 +112,6 @@ $mod_strings = array(
 	'Export Results' => 'Export Results',
 	'Value' => 'Value',
 	'querytype' => 'Query Type',
+	'Direct Sql' => 'Direct Sql',
 );
 ?>

--- a/modules/cbupdater/cbupdater.xml
+++ b/modules/cbupdater/cbupdater.xml
@@ -1361,4 +1361,11 @@
 	<classname>AddColumnsForOutgoingServerConfigurationValues</classname>
 	<systemupdate>true</systemupdate>
 </changeSet>
+<changeSet>
+	<author>arditramaj</author>
+	<description>Add field to cbQuestion module for direct sql</description>
+	<filename>build/changeSets/2023/addBQforDirectSql.php</filename>
+	<classname>addBQforDirectSql</classname>
+	<systemupdate>true</systemupdate>
+</changeSet>
 </updatesChangeLog>


### PR DESCRIPTION
Added direct sql to the business question for complex operations that webservice does not support. In this pull request these things have changes:

- added class addBQforDirectSql to the changeset
- updated cbupdater with the added changeset
- created an eventlistener on change for disabling textarea when pure sql is going to be written
- added check for directsql to the cbQuestion.php in function getSQL.

