### PR TITLE
Underscore not working in search

### DIFF
--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -508,6 +508,7 @@ class QueryGenerator {
 	}
 
 	public function getQuery($distinct = false, $limit = '') {
+		global $adb;
 		if (empty($this->query)) {
 			$allFields = array_merge($this->whereFields, $this->fields);
 			foreach ($allFields as $fieldName) {
@@ -528,7 +529,7 @@ class QueryGenerator {
 			$sql_query .= $this->getFromClause();
 			if ($this->meta->getTabName() == 'Documents' && $this->SearchDocuments) {
 				$search_text = vtlib_purify($_REQUEST['search_text']);
-				$sql_query .= ' WHERE vtiger_documentsearchinfo.text LIKE "%'.$search_text.'%" AND vtiger_notes.notesid>0';
+				$sql_query = $adb->convert2sql(' WHERE vtiger_documentsearchinfo.text LIKE ? AND vtiger_notes.notesid>0', ["%" . $search_text . "%"]);
 			} else {
 				$sql_query .= $this->getWhereClause();
 			}

--- a/include/QueryGenerator/QueryGenerator.php
+++ b/include/QueryGenerator/QueryGenerator.php
@@ -1421,27 +1421,33 @@ class QueryGenerator {
 					break;
 				case 's':
 					$sqlOperator = 'LIKE';
+					$value = escapeUnderscores($value);
 					$value = "$value%";
 					break;
 				case 'ew':
 					$sqlOperator = 'LIKE';
+					$value = escapeUnderscores($value);
 					$value = "%$value";
 					break;
 				case 'c':
 				case 'cnc':
 					$sqlOperator = 'LIKE';
+					$value = escapeUnderscores($value);
 					$value = "%$value%";
 					break;
 				case 'k':
 					$sqlOperator = 'NOT LIKE';
+					$value = escapeUnderscores($value);
 					$value = "%$value%";
 					break;
 				case 'dnsw':
 					$sqlOperator = 'NOT LIKE';
+					$value = escapeUnderscores($value);
 					$value = "$value%";
 					break;
 				case 'dnew':
 					$sqlOperator = 'NOT LIKE';
+					$value = escapeUnderscores($value);
 					$value = "%$value";
 					break;
 				case 'monthday':

--- a/include/utils/utils.php
+++ b/include/utils/utils.php
@@ -3925,4 +3925,8 @@ function convertPathFromAbsoluteToRelative($absolutePath) {
 	}
 	return substr($absolutePath, $prefix_pos + strlen($root_directory));
 }
+
+function escapeUnderscores($sql) {
+	return str_replace('_', '\_', $sql);
+}
 ?>


### PR DESCRIPTION
When trying to search the string "_text" it will consider the underscore as a wildcard that represents any value. in order to fix this we need to escape the underscore in the string.